### PR TITLE
Reduce wordiness, add hints for those coming from ros(1)_control

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,40 +5,46 @@
 [![Coverage Status](https://github.com/ros-controls/ros2_control_demos/workflows/Coverage/badge.svg?branch=master)](https://github.com/ros-controls/ros2_control_demos/actions?query=workflow%3ACoverage)
 [![Licence](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-This repository provides templates for the development of `ros2_control`-enabled robots and a simple simulation of a robot to demonstrate and prove `ros2_control` concepts.
-
-**ATTENTION: `ros2_control` is currently under heavy development and the any APIs implementation in this repositry, can be broken without any announcement!**
+This repository provides templates for the development of `ros2_control`-enabled robots and a simple simulation of a robot.
 
 ## Goals
 
 The repository has three goals:
 1. Implements the example configuration described in the `ros-controls/roadmap` repository file [components_architecture_and_urdf_examples](https://github.com/ros-controls/roadmap/blob/master/design_drafts/components_architecture_and_urdf_examples.md).
-2. It provides templates for faster start of implementing own hardware and controllers;
+2. It provides templates for faster implementation of custom hardware and controllers;
 3. The repository is a validation environment for `ros2_control` concepts, which can only be tested during run-time (e.g., execution of controllers by the controller manager, communication between robot hardware and controllers).
 
 
 ## Description
 
-The repository is inspired by [ros_control_boilerplate](https://github.com/PickNikRobotics/ros_control_boilerplate) repository from Dave Coleman.
+The repository is inspired by the [ros_control_boilerplate](https://github.com/PickNikRobotics/ros_control_boilerplate) repository from Dave Coleman.
 The simulation has three parts/packages:
 1. The first package, `ros2_control_demo_hardware`, implements the hardware interfaces described in the roadmap.
-This implemented examples simulate *RRbot* internally to provide sufficient test and demonstration data, but to reduce amount of package dependencies.
-This package does not have any dependencies except on the `ros2` core packages and can, therefore, be used on SoC-hardware of headless systems.
-2. The second package, `ros2_control_demo_hardware_gazebo`, uses a gazebo simulator to simulate the *RRBot* and its physics.
-This package is useful to test the connection of `ros2_control` to the gazebo simulator and to detect any missing plugins.
+The examples simulate a simple *RRbot* internally to provide sufficient test and demonstration data and reduce external dependencies.
+This package does not have any dependencies except `ros2` core packages and can, therefore, be used on SoC-hardware of headless systems.
+2. The second package, `ros2_control_demo_hardware_gazebo`, uses a Gazebo simulator to simulate the *RRBot* and its physics.
+This package is useful to test the connection of `ros2_control` to the Gazebo simulator and to detect any missing plugins.
 3. The third package `ros2_control_demo_robot` holds examples for *RRbot* URDF-description, launch files and controllers.
-The intention of those files is to simplify start with `ros2_control` and to enable faster integration of new robots and controllers.
 
 This repository demonstrates the following `ros2_control` concepts:
 
 * Creating of `*HardwareInterface` for a System, Sensor, and Actuator.
 * Creating a robot description in the form of URDF files
-* Loading configuration and starting robot using launch files 
+* Loading the configuration and starting a robot using launch files 
 * Control of two joints of *RRBot*
-* Using simulated robots and starting `ros_control` with gazebo simulator
+* Using simulated robots and starting `ros_control` with Gazebo simulator
 * Implementing of controller switching strategy for a robot
 * Using joint limits and transmission concepts in `ros2_control`
-* TBD...
+
+## Quick Hints
+
+These are some quick hints, especially for those coming from a ROS1 control background:
+
+* There are now three categories of hardware interface: *Sensor*, *Actuator*, and *System*. Sensor is for individual sensors; Actuator is for individual actuators; System is for any combination of multiple sensors/actuators. You could think of a Sensor as read-only.
+* ros(1)_control only allowed three hardware interface types: position, velocity, and effort. ros2_control allows you to create any interface type by defining a custom string. For example, you might define a `position_in_degrees` or a `temperature` interface. The most common (position, velocity, acceleration, effort) are already defined as constants in hardware_interface/types/hardware_interface_type_values.hpp.
+* In ros2_control, all parameters for the driver are specified in the URDF. The ros2_control framework uses the <ros2_control> tag in the URDF.
+* <ros2_control> tags in the URDF must be compatible with the controller's configuration.
+* PLUGINLIB_EXPORT_CLASS macro is required when implementing an interface.
 
 # Test of the Scenario Before the First Release
 * Checkout [ros-controls/ros2_control](https://github.com/ros-controls/ros2_control) to get the core.
@@ -83,13 +89,13 @@ Each of the described example cases from the roadmap has its own launch and URDF
          joint2/position
   ```
 
-3. Open another terminal and load, configure and start controllers:
+3. Open another terminal and load, configure, and start controllers:
   ```
   ros2 control load_start_controller joint_state_controller
   ros2 control load_configure_controller forward_command_controller_position
   ```
   
-  Check if controller is loaded properly:
+  Check if the controller is loaded properly:
   ```
   ros2 control list_controllers
   ```


### PR DESCRIPTION
- Remove a warning about unstable API since (as far as I know) the API should be stable now.
- Add a hints section for those coming from ros(1)_control.
- Reduce wordiness in a few places. It seemed like there was some redundancy, especially in stating goals of the package multiple times.
- Minor grammar cleanup.