### PR TITLE
[Example 2]: Started multi_interface example

### DIFF
--- a/ros2_control_demo_hardware/CMakeLists.txt
+++ b/ros2_control_demo_hardware/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   ${PROJECT_NAME}
   SHARED
   src/rrbot_system_position_only.cpp
+  src/rrbot_system_multi_interface.cpp
 )
 target_include_directories(
   ${PROJECT_NAME}

--- a/ros2_control_demo_hardware/include/ros2_control_demo_hardware/rrbot_system_multi_interface.hpp
+++ b/ros2_control_demo_hardware/include/ros2_control_demo_hardware/rrbot_system_multi_interface.hpp
@@ -1,0 +1,65 @@
+#ifndef ROS2_CONTROL_DEMO_HARDWARE__RRBOT_MULTI_INTERFACE_HPP_
+#define ROS2_CONTROL_DEMO_HARDWARE__RRBOT_MULTI_INTERFACE_HPP_
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "rclcpp/macros.hpp"
+
+#include "hardware_interface/base_interface.hpp"
+#include "hardware_interface/system_interface.hpp"
+#include "hardware_interface/handle.hpp"
+#include "hardware_interface/hardware_info.hpp"
+#include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "hardware_interface/types/hardware_interface_status_values.hpp"
+#include "ros2_control_demo_hardware/visibility_control.h"
+
+using hardware_interface::return_type;
+
+namespace ros2_control_demo_hardware
+{
+class RRBotSystemMultiInterfaceHardware : public
+  hardware_interface::BaseInterface<hardware_interface::SystemInterface>
+{
+public:
+  RCLCPP_SHARED_PTR_DEFINITIONS(RRBotSystemMultiInterfaceHardware);
+
+  ROS2_CONTROL_DEMO_HARDWARE_PUBLIC
+  return_type configure(const hardware_interface::HardwareInfo & info) override;
+
+  ROS2_CONTROL_DEMO_HARDWARE_PUBLIC
+  std::vector<hardware_interface::StateInterface> export_state_interfaces() override;
+
+  ROS2_CONTROL_DEMO_HARDWARE_PUBLIC
+  std::vector<hardware_interface::CommandInterface> export_command_interfaces() override;
+
+  ROS2_CONTROL_DEMO_HARDWARE_PUBLIC
+  return_type start() override;
+
+  ROS2_CONTROL_DEMO_HARDWARE_PUBLIC
+  return_type stop() override;
+
+  ROS2_CONTROL_DEMO_HARDWARE_PUBLIC
+  return_type read() override;
+
+  ROS2_CONTROL_DEMO_HARDWARE_PUBLIC
+  return_type write() override;
+
+private:
+  // Parameters for the RRBot simulation
+  double hw_start_sec_;
+  double hw_stop_sec_;
+  double hw_slowdown_;
+
+  // Store the commands for the simulated robot
+  std::vector<double> hw_commands_positions_;
+  std::vector<double> hw_commands_velocities_;
+  std::vector<double> hw_commands_accelerations_;
+  std::vector<double> hw_positions_;
+  std::vector<double> hw_velocities_;
+  std::vector<double> hw_accelerations_;
+};
+
+}  // namespace ros2_control_demo_hardware
+#endif // ROS2_CONTROL_DEMO_HARDWARE__RRBOT_MULTI_INTERFACE_HPP_

--- a/ros2_control_demo_hardware/ros2_control_demo_hardware.xml
+++ b/ros2_control_demo_hardware/ros2_control_demo_hardware.xml
@@ -6,4 +6,11 @@
       The ROS2 Control minimal robot protocol. This is example for start porting the robot from ROS 1.
     </description>
   </class>
+  <class name="ros2_control_demo_hardware/RRBotSystemMultiInterfaceHardware"
+         type="ros2_control_demo_hardware::RRBotSystemMultiInterfaceHardware"
+         base_class_type="hardware_interface::SystemInterface">
+    <description>
+      The ROS2 Control minimal robot protocol for a system with multiple command and state interfaces.
+    </description>
+  </class>
 </library>

--- a/ros2_control_demo_hardware/src/rrbot_system_multi_interface.cpp
+++ b/ros2_control_demo_hardware/src/rrbot_system_multi_interface.cpp
@@ -1,0 +1,235 @@
+#include "ros2_control_demo_hardware/rrbot_system_multi_interface.hpp"
+
+#include <chrono>
+#include <cmath>
+#include <limits>
+#include <memory>
+#include <vector>
+
+#include "hardware_interface/types/hardware_interface_type_values.hpp"
+#include "rclcpp/rclcpp.hpp"
+
+namespace ros2_control_demo_hardware
+{
+
+return_type RRBotSystemMultiInterfaceHardware::configure(
+  const hardware_interface::HardwareInfo & info)
+{
+  if (configure_default(info) != return_type::OK) {
+    return return_type::ERROR;
+  }
+
+  hw_start_sec_ = stod(info_.hardware_parameters["example_param_hw_start_duration_sec"]);
+  hw_stop_sec_ = stod(info_.hardware_parameters["example_param_hw_stop_duration_sec"]);
+  hw_slowdown_ = stod(info_.hardware_parameters["example_param_hw_slowdown"]);
+  hw_positions_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+  hw_velocities_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+  hw_accelerations_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+  hw_commands_positions_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+  hw_commands_velocities_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+  hw_commands_accelerations_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
+
+  for (const hardware_interface::ComponentInfo & joint : info_.joints) {
+    // RRBotSystemMultiInterface has exactly 3 state interfaces and 3 command interfaces on each joint
+    if (joint.command_interfaces.size() != 3) {
+      RCLCPP_FATAL(
+        rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+        "Joint '%s' has %d command interfaces. 3 expected.",
+        joint.name.c_str());
+      return return_type::ERROR;
+    }
+    
+    if ( !(joint.command_interfaces[0].name == hardware_interface::HW_IF_POSITION ||
+           joint.command_interfaces[0].name == hardware_interface::HW_IF_VELOCITY ||
+           joint.command_interfaces[0].name == hardware_interface::HW_IF_ACCELERATION)) {
+      RCLCPP_FATAL(
+        rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+        "Joint '%s' has %s command interface. Expected %s, %s, or %s.",
+        joint.name.c_str(), joint.command_interfaces[0].name.c_str(),
+        hardware_interface::HW_IF_POSITION, hardware_interface::HW_IF_VELOCITY,
+        hardware_interface::HW_IF_ACCELERATION);
+      return return_type::ERROR;
+    }
+
+    if (joint.state_interfaces.size() != 3) {
+      RCLCPP_FATAL(
+        rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+        "Joint '%s'has %d state interfaces. 3 expected.",
+        joint.name.c_str());
+      return return_type::ERROR;
+    }
+
+    if ( !(joint.state_interfaces[0].name == hardware_interface::HW_IF_POSITION ||
+           joint.state_interfaces[0].name == hardware_interface::HW_IF_VELOCITY ||
+           joint.state_interfaces[0].name == hardware_interface::HW_IF_ACCELERATION) ) {
+      RCLCPP_FATAL(
+        rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+        "Joint '%s' has %s state interface. Expected %s, %s, or %s.",
+        joint.name.c_str(), joint.state_interfaces[0].name.c_str(),
+        hardware_interface::HW_IF_POSITION, hardware_interface::HW_IF_VELOCITY,
+        hardware_interface::HW_IF_ACCELERATION);
+      return return_type::ERROR;
+    }
+  }
+
+  status_ = hardware_interface::status::CONFIGURED;
+  return return_type::OK;
+}
+
+std::vector<hardware_interface::StateInterface>
+RRBotSystemMultiInterfaceHardware::export_state_interfaces()
+{
+  std::vector<hardware_interface::StateInterface> state_interfaces;
+  for (uint i = 0; i < info_.joints.size(); i++) {
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &hw_positions_[i]));
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &hw_velocities_[i]));
+    state_interfaces.emplace_back(
+      hardware_interface::StateInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_ACCELERATION, &hw_accelerations_[i]));
+  }
+
+  return state_interfaces;
+}
+
+std::vector<hardware_interface::CommandInterface>
+RRBotSystemMultiInterfaceHardware::export_command_interfaces()
+{
+  std::vector<hardware_interface::CommandInterface> command_interfaces;
+  for (uint i = 0; i < info_.joints.size(); i++) {
+    command_interfaces.emplace_back(
+      hardware_interface::CommandInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_POSITION, &hw_commands_positions_[i]));
+    command_interfaces.emplace_back(
+      hardware_interface::CommandInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_VELOCITY, &hw_commands_velocities_[i]));
+    command_interfaces.emplace_back(
+      hardware_interface::CommandInterface(
+        info_.joints[i].name, hardware_interface::HW_IF_ACCELERATION, &hw_commands_accelerations_[i]));
+  }
+
+  return command_interfaces;
+}
+
+return_type RRBotSystemMultiInterfaceHardware::start()
+{
+  RCLCPP_INFO(
+    rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+    "Starting... please wait...");
+  
+  for (int i = 0; i <= hw_start_sec_; i++) {
+    rclcpp::sleep_for(std::chrono::seconds(1));
+    RCLCPP_INFO(
+      rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+      "%.1f seconds left...", hw_start_sec_ -i);
+  }
+
+  // Set some default values
+  for (uint i = 0; i < hw_positions_.size(); i++) {
+    if (std::isnan(hw_positions_[i])) {
+      hw_positions_[i] = 0;
+    }
+    if (std::isnan(hw_velocities_[i])) {
+      hw_velocities_[i] = 0;
+    }
+    if (std::isnan(hw_accelerations_[i])) {
+      hw_accelerations_[i] = 0;
+    }
+    if (std::isnan(hw_commands_positions_[i])) {
+      hw_commands_positions_[i] = 0;
+    }
+    if (std::isnan(hw_commands_velocities_[i])) {
+      hw_commands_velocities_[i] = 0;
+    }
+    if (std::isnan(hw_commands_accelerations_[i])) {
+      hw_commands_accelerations_[i] = 0;
+    }
+  }
+  status_ = hardware_interface::status::STARTED;
+
+  RCLCPP_INFO(
+    rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+    "System succesfully started!");
+  return return_type::OK;
+}
+
+return_type RRBotSystemMultiInterfaceHardware::stop()
+{
+  RCLCPP_INFO(
+    rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+    "Stopping... please wait...");
+  
+  for (int i = 0; i <= hw_stop_sec_; i++) {
+    rclcpp::sleep_for(std::chrono::seconds(1));
+    RCLCPP_INFO(
+      rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+      "%.1f seconds left...", hw_stop_sec_ - i);
+  }
+
+  status_ = hardware_interface::status::STOPPED;
+
+  RCLCPP_INFO(
+    rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+    "System succesfully stopped!");
+  
+  return return_type::OK;
+}
+
+
+
+return_type RRBotSystemMultiInterfaceHardware::read()
+{
+  RCLCPP_INFO(
+    rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+    "Reading...");
+  
+  for (uint  i = 0; i < hw_positions_.size(); i++) {
+    // Simulate RRBot's movement, this has three scenarios actually:
+    // 1. The position command interfaces have been claimed, update according to them
+    // 2. The velocity command interfaces have been claimed, update according to them
+    // 3. The acceleration command interfaces have been claimed, update according to them
+    // Since I don't know how to figure out which resource has been claimed:
+    hw_positions_[i] = hw_commands_positions_[i] + (hw_positions_[i] - hw_commands_positions_[i]) / hw_slowdown_;
+    RCLCPP_INFO(
+      rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+      "Got pos: %.5f, vel: %.5f, acc: %.5f for joint %d!",
+      hw_positions_[i], hw_velocities_[i],
+      hw_accelerations_[i], i);
+  }
+  RCLCPP_INFO(
+    rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+    "Joints succesfully read!");
+
+  return return_type::OK;
+}
+
+return_type RRBotSystemMultiInterfaceHardware::write()
+{
+  RCLCPP_INFO(
+    rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+    "Writing...");
+  for (uint i = 0; i < hw_commands_positions_.size(); i++) {
+    // Simulate sending commands to the hardware
+    RCLCPP_INFO(
+      rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+      "Got the commands pos: %.5f, vel: %.5f, acc: %.5f for joint %d", 
+      hw_commands_positions_[i], hw_commands_velocities_[i],
+      hw_commands_accelerations_[i], i);
+  }
+  RCLCPP_INFO(
+    rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
+    "Joint succesfully written!");
+  return return_type::OK;
+}
+
+}  // namespace ros2_control_demo_hardware
+
+#include "pluginlib/class_list_macros.hpp"
+
+PLUGINLIB_EXPORT_CLASS(
+  ros2_control_demo_hardware::RRBotSystemMultiInterfaceHardware,
+  hardware_interface::SystemInterface
+)

--- a/ros2_control_demo_robot/description/rrbot/rrbot_system_multi_interface.ros2_control.xacro
+++ b/ros2_control_demo_robot/description/rrbot/rrbot_system_multi_interface.ros2_control.xacro
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <xacro:macro name="rrbot_system_multi_interface" params="name prefix">
+
+    <ros2_control name="${name}" type="system">
+      <hardware>
+        <plugin>ros2_control_demo_hardware/RRBotSystemMultiInterfaceHardware</plugin>
+        <param name="example_param_hw_start_duration_sec">2.0</param>
+        <param name="example_param_hw_stop_duration_sec">3.0</param>
+        <param name="example_param_hw_slowdown">2.0</param>
+      </hardware>
+      <joint name="joint1">
+        <command_interface name="position">
+          <param name="min">-1</param>
+          <param name="max">1</param>
+        </command_interface>
+        <command_interface name="velocity">
+          <param name="min">-1</param>
+          <param name="max">1</param>
+        </command_interface>
+        <command_interface name="acceleration">
+          <param name="min">-1</param>
+          <param name="max">1</param>
+        </command_interface>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="acceleration"/>
+      </joint>
+      <joint name="joint2">
+        <command_interface name="position">
+          <param name="min">-1</param>
+          <param name="max">1</param>
+        </command_interface>
+        <command_interface name="velocity">
+          <param name="min">-1</param>
+          <param name="max">1</param>
+        </command_interface>
+        <command_interface name="acceleration">
+          <param name="min">-1</param>
+          <param name="max">1</param>
+        </command_interface>
+        <state_interface name="position"/>
+        <state_interface name="velocity"/>
+        <state_interface name="acceleration"/>
+      </joint>
+    </ros2_control>
+
+  </xacro:macro>
+
+</robot>
+

--- a/ros2_control_demo_robot/description/rrbot_system_multi_interface.urdf.xacro
+++ b/ros2_control_demo_robot/description/rrbot_system_multi_interface.urdf.xacro
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<!-- Revolute-Revolute Manipulator -->
+<!--
+Copied and modified from ROS1 example:
+https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_description/urdf/rrbot.xacro
+-->
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="2dof_robot">
+
+  <!-- Import RRBot macro -->
+  <xacro:include filename="rrbot/rrbot.urdf.xacro" />
+  <!-- <xacro:include filename="$(find ros2_control_demo_robot)/description/rrbot/rrbot.urdf.xacro" /> -->
+
+  <!-- Import all Gazebo-customization elements, including Gazebo colors -->
+  <xacro:include filename="rrbot/rrbot.gazebo.xacro" />
+  <!-- <xacro:include filename="$(find ros2_control_demo_robot)/description/rrbot/rrbot.gazebo.xacro" /> -->
+
+  <!-- Import Rviz colors -->
+  <xacro:include filename="rrbot/rrbot.materials.xacro" />
+  <!-- <xacro:include filename="$(find ros2_control_demo_robot)/description/rrbot/rrbot.materials.xacro" /> -->
+
+  <!-- Import RRBot ros2_control description -->
+  <xacro:include filename="rrbot/rrbot_system_multi_interface.ros2_control.xacro" />
+
+  <!-- Used for fixing robot -->
+  <link name="world"/>
+  <gazebo reference="world">
+    <static>true</static>
+  </gazebo>
+
+  <xacro:rrbot parent="world" prefix="">
+    <origin xyz="0 0 0" rpy="0 0 0" />
+  </xacro:rrbot>
+
+  <xacro:rrbot_gazebo prefix="" />
+
+  <xacro:rrbot_system_multi_interface name="RRBotSystemMultiInterface" prefix="" />
+
+</robot>

--- a/ros2_control_demo_robot/launch/rrbot_system_multi_interface.launch.py
+++ b/ros2_control_demo_robot/launch/rrbot_system_multi_interface.launch.py
@@ -1,0 +1,37 @@
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+import xacro
+
+
+def generate_launch_description():
+
+  # Get URDF via xacro
+  robot_description_path = os.path.join(
+    get_package_share_directory('ros2_control_demo_robot'),
+    'description',
+    'rrbot_system_multi_interface.urdf.xacro')
+  robot_description_config = xacro.process_file(robot_description_path)
+  robot_description = {'robot_description': robot_description_config.toxml()}
+  print(robot_description_config.toxml())
+  rrbot_forward_controller = os.path.join(
+    get_package_share_directory('ros2_control_demo_robot'),
+    'controllers',
+    'rrbot_forward_controller_position.yaml'
+  )
+
+  return LaunchDescription([
+    Node(
+      package='controller_manager',
+      executable='ros2_control_node',
+      parameters=[robot_description, rrbot_forward_controller],
+      output={
+        'stdout': 'screen',
+        'stderr': 'screen'
+      }
+    )
+  ])


### PR DESCRIPTION
Started `multi_interface` example. Waiting for clarification of how to identify which command interface has been claimed from the `hardware_interface` side before completing, see: https://github.com/ros-controls/ros2_control_demos/issues/59
