### PR TITLE
Adding Gazebo for rrbot

### DIFF
--- a/ros2_control_demo_robot/controllers/rrbot_gazebo_forward_controller_position.yaml
+++ b/ros2_control_demo_robot/controllers/rrbot_gazebo_forward_controller_position.yaml
@@ -1,0 +1,16 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 100  # Hz
+
+    joint_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    joint_state_controller:
+      type: joint_state_controller/JointStateController
+
+joint_trajectory_controller:
+  ros__parameters:
+    joints:
+      - joint1
+      - joint2
+    interface_name: position

--- a/ros2_control_demo_robot/description/rrbot/rrbot.gazebo.xacro
+++ b/ros2_control_demo_robot/description/rrbot/rrbot.gazebo.xacro
@@ -9,9 +9,8 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_desc
 
     <!-- ros_control plugin -->
     <gazebo>
-      <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
-        <robotNamespace>/rrbot</robotNamespace>
-        <robotSimType>gazebo_ros_control/DefaultRobotHWSim</robotSimType>
+      <plugin name="gazebo_ros2_control" filename="libgazebo_ros2_control.so">
+        <parameters>$(find ros2_control_demo_robot)/controllers/rrbot_gazebo_forward_controller_position.yaml</parameters>
       </plugin>
     </gazebo>
 

--- a/ros2_control_demo_robot/description/rrbot/rrbot_system_position_only.ros2_control.xacro
+++ b/ros2_control_demo_robot/description/rrbot/rrbot_system_position_only.ros2_control.xacro
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="rrbot_system_position_only" params="name prefix simu:='false' ">
+  <xacro:macro name="rrbot_system_position_only" params="name prefix use_sim:='false' ">
 
     <ros2_control name="${name}" type="system">
 
-      <xacro:if value="$(arg simu)">
+      <xacro:if value="$(arg use_sim)">
         <hardware>
           <plugin>gazebo_ros2_control/GazeboSystem</plugin>
         </hardware>
       </xacro:if>
-      <xacro:unless value="$(arg simu)">
+      <xacro:unless value="$(arg use_sim)">
         <hardware>
           <plugin>ros2_control_demo_hardware/RRBotSystemPositionOnlyHardware</plugin>
           <param name="example_param_hw_start_duration_sec">2.0</param>

--- a/ros2_control_demo_robot/description/rrbot/rrbot_system_position_only.ros2_control.xacro
+++ b/ros2_control_demo_robot/description/rrbot/rrbot_system_position_only.ros2_control.xacro
@@ -1,15 +1,24 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="rrbot_system_position_only" params="name prefix">
+  <xacro:macro name="rrbot_system_position_only" params="name prefix simu:='false' ">
 
     <ros2_control name="${name}" type="system">
-      <hardware>
-        <plugin>ros2_control_demo_hardware/RRBotSystemPositionOnlyHardware</plugin>
-        <param name="example_param_hw_start_duration_sec">2.0</param>
-        <param name="example_param_hw_stop_duration_sec">3.0</param>
-        <param name="example_param_hw_slowdown">2.0</param>
-      </hardware>
+
+      <xacro:if value="$(arg simu)">
+        <hardware>
+          <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+        </hardware>
+      </xacro:if>
+      <xacro:unless value="$(arg simu)">
+        <hardware>
+          <plugin>ros2_control_demo_hardware/RRBotSystemPositionOnlyHardware</plugin>
+          <param name="example_param_hw_start_duration_sec">2.0</param>
+          <param name="example_param_hw_stop_duration_sec">3.0</param>
+          <param name="example_param_hw_slowdown">2.0</param>
+        </hardware>
+      </xacro:unless>
+
       <joint name="joint1">
         <command_interface name="position">
           <param name="min">-1</param>
@@ -29,4 +38,3 @@
   </xacro:macro>
 
 </robot>
-

--- a/ros2_control_demo_robot/description/rrbot_system_position_only.urdf.xacro
+++ b/ros2_control_demo_robot/description/rrbot_system_position_only.urdf.xacro
@@ -5,7 +5,8 @@ Copied and modified from ROS1 example:
 https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_description/urdf/rrbot.xacro
 -->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="2dof_robot">
-
+  <xacro:arg name="simu" default="false" />
+  
   <!-- Import RRBot macro -->
   <xacro:include filename="rrbot/rrbot.urdf.xacro" />
   <!-- <xacro:include filename="$(find ros2_control_demo_robot)/description/rrbot/rrbot.urdf.xacro" /> -->
@@ -34,6 +35,6 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_desc
 
   <xacro:rrbot_gazebo prefix="" />
 
-  <xacro:rrbot_system_position_only name="RRBotSystemPositionOnly" prefix="" />
+  <xacro:rrbot_system_position_only name="RRBotSystemPositionOnly" prefix="" simu="$(arg simu)" />
 
 </robot>

--- a/ros2_control_demo_robot/description/rrbot_system_position_only.urdf.xacro
+++ b/ros2_control_demo_robot/description/rrbot_system_position_only.urdf.xacro
@@ -5,7 +5,7 @@ Copied and modified from ROS1 example:
 https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_description/urdf/rrbot.xacro
 -->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="2dof_robot">
-  <xacro:arg name="simu" default="false" />
+  <xacro:arg name="use_sim" default="false" />
   
   <!-- Import RRBot macro -->
   <xacro:include filename="rrbot/rrbot.urdf.xacro" />
@@ -35,6 +35,6 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_desc
 
   <xacro:rrbot_gazebo prefix="" />
 
-  <xacro:rrbot_system_position_only name="RRBotSystemPositionOnly" prefix="" simu="$(arg simu)" />
+  <xacro:rrbot_system_position_only name="RRBotSystemPositionOnly" prefix="" use_sim="$(arg use_sim)" />
 
 </robot>

--- a/ros2_control_demo_robot/launch/rrbot_system_position_only_gazebo.launch.py
+++ b/ros2_control_demo_robot/launch/rrbot_system_position_only_gazebo.launch.py
@@ -38,7 +38,7 @@ def generate_launch_description():
         'rrbot_system_position_only.urdf.xacro')
     robot_description_config = xacro.process_file(
         robot_description_path,
-        mappings={'simu': 'true'})
+        mappings={'use_sim': 'true'})
     robot_description = {'robot_description': robot_description_config.toxml()}
 
     node_robot_state_publisher = Node(

--- a/ros2_control_demo_robot/launch/rrbot_system_position_only_gazebo.launch.py
+++ b/ros2_control_demo_robot/launch/rrbot_system_position_only_gazebo.launch.py
@@ -50,7 +50,7 @@ def generate_launch_description():
 
     spawn_entity = Node(package='gazebo_ros', executable='spawn_entity.py',
                         arguments=['-topic', 'robot_description',
-                                   '-entity', 'cartpole'],
+                                   '-entity', 'rrbot_system_position'],
                         output='screen')
 
     return LaunchDescription([

--- a/ros2_control_demo_robot/launch/rrbot_system_position_only_gazebo.launch.py
+++ b/ros2_control_demo_robot/launch/rrbot_system_position_only_gazebo.launch.py
@@ -1,0 +1,62 @@
+# Copyright 2020 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+
+from launch_ros.actions import Node
+
+import xacro
+
+
+def generate_launch_description():
+    gazebo = IncludeLaunchDescription(
+                PythonLaunchDescriptionSource([os.path.join(
+                    get_package_share_directory('gazebo_ros'), 'launch'), '/gazebo.launch.py']),
+             )
+
+    ros2_control_demos_path = os.path.join(
+        get_package_share_directory('ros2_control_demos'))
+
+    robot_description_path = os.path.join(
+        get_package_share_directory('ros2_control_demo_robot'),
+        'description',
+        'rrbot_system_position_only.urdf.xacro')
+    robot_description_config = xacro.process_file(robot_description_path,
+    mappings={'simu' : 'true'})
+    robot_description = {'robot_description': robot_description_config.toxml()}
+
+    node_robot_state_publisher = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        output='screen',
+        parameters=[robot_description]
+    )
+
+    spawn_entity = Node(package='gazebo_ros', executable='spawn_entity.py',
+                        arguments=['-topic', 'robot_description',
+                                   '-entity', 'cartpole'],
+                        output='screen')
+
+    return LaunchDescription([
+        gazebo,
+        node_robot_state_publisher,
+        spawn_entity,
+    ])

--- a/ros2_control_demo_robot/launch/rrbot_system_position_only_gazebo.launch.py
+++ b/ros2_control_demo_robot/launch/rrbot_system_position_only_gazebo.launch.py
@@ -1,4 +1,4 @@
-# Copyright 2020 Open Source Robotics Foundation, Inc.
+# Copyright 2021 Open Source Robotics Foundation, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ros2_control_demo_robot/launch/rrbot_system_position_only_gazebo.launch.py
+++ b/ros2_control_demo_robot/launch/rrbot_system_position_only_gazebo.launch.py
@@ -32,15 +32,13 @@ def generate_launch_description():
                     get_package_share_directory('gazebo_ros'), 'launch'), '/gazebo.launch.py']),
              )
 
-    ros2_control_demos_path = os.path.join(
-        get_package_share_directory('ros2_control_demos'))
-
     robot_description_path = os.path.join(
         get_package_share_directory('ros2_control_demo_robot'),
         'description',
         'rrbot_system_position_only.urdf.xacro')
-    robot_description_config = xacro.process_file(robot_description_path,
-    mappings={'simu' : 'true'})
+    robot_description_config = xacro.process_file(
+        robot_description_path,
+        mappings={'simu': 'true'})
     robot_description = {'robot_description': robot_description_config.toxml()}
 
     node_robot_state_publisher = Node(

--- a/ros2_control_demo_robot/package.xml
+++ b/ros2_control_demo_robot/package.xml
@@ -16,6 +16,8 @@
   <depend>rclcpp</depend>
   <depend>gazebo_ros2_control</depend>
 
+  <exec_depend>xacro</exec_depend>
+
   <depend>ros2_control_demo_hardware</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/ros2_control_demo_robot/package.xml
+++ b/ros2_control_demo_robot/package.xml
@@ -14,6 +14,7 @@
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
+  <depend>gazebo_ros2_control</depend>
 
   <depend>ros2_control_demo_hardware</depend>
 


### PR DESCRIPTION
Objective
=======
Following the nice work of @ahcorde on gazebo_ros2_control adding Gazebo for rrbot.

This pull requests modifies the rrbot_description to call the `gazebo_ros2_control`  and the `GazeboSystem`plugins.
Given the interfaces of rrbot this is directly compatible.
The rrbot_system_description_position_only.urdf.xacro has been modified to take simu has parameter.
The default is false and switch quietly to the usual behavior.
If set to true it loads the gazebo system from `gazebo_ros2_control`.

The `rrbot_gazebo.xacro` and `rrbot_system_position_only.ros2_control.xacro` are modified accordingly.

What is left ?
==========

* **Major**: Testing by sending commands to the system. Should we try to use the same forward_command_trajectory or use the same example than `gazebo_ros2_control` ? The latter might lead to an unnecessary duplication of code between the two repositories.

* **Minor**: Modifying the README to launch the test:
`ros2 launch ros2_control_demo_robot rrbot_system_position_only_gazebo.launch.py`