### PR TITLE
Upgrade codecov-action version.

### DIFF
--- a/.github/workflows/ci-build-coverage.yml
+++ b/.github/workflows/ci-build-coverage.yml
@@ -35,7 +35,7 @@ jobs:
               }
             }
           colcon-mixin-repository: https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
-      - uses: codecov/codecov-action@v1.0.14
+      - uses: codecov/codecov-action@v1.5.0
         with:
           file: ros_ws/lcov/total_coverage.info
           flags: unittests


### PR DESCRIPTION
Codecov recently announced an issue with their bash upload script.
Details of the incident can be found at https://about.codecov.io/security-update/

In order to help protect against similar future issues, the
codecov-action was first updated in 1.4.0 to verify the script after
downloading and in 1.5.0 the current version of the upload script has
been vendored into the action.

Workflows which specify the `@v1` tag will automatically use the latest
1.x version of the action as long as codecov continue to update the v1
tag. Since this workflow uses pinned action versions I have updated the
version to 1.5.0. Any version >=1.4.0 is sufficient to verify the upload
script but since 1.5.0 is the latest version as of now I decided to bump
to it.