### PR TITLE
The dependency is one down

### DIFF
--- a/ros2_control_demo_bringup/package.xml
+++ b/ros2_control_demo_bringup/package.xml
@@ -17,7 +17,6 @@
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ros2_control_demo_description</exec_depend>
-  <exec_depend>ros2_control_demo_hardware</exec_depend>
   <exec_depend>ros2_control_test_nodes</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>

--- a/ros2_control_demo_description/package.xml
+++ b/ros2_control_demo_description/package.xml
@@ -13,6 +13,7 @@
 
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>ros2_control_demo_hardware</exec_depend>
   <exec_depend>rviz2</exec_depend>
 
   <export>


### PR DESCRIPTION
This matters to us because we install per-package, not per git repository.