### PR TITLE
Make Gazebo simulation works again

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ Available launch-file options:
     This is a simple simulation that mimics joint command to their states.
     This is useful to test *ros2_control* integration and controllers without physical hardware.
 
+For gazebo:
+   ```
+   ros2 launch ros2_control_demo_bringup rrbot_system_position_only_gazebo.launch.py
+   ```
+
+To start the forward position:
+   ```
+   ros2 launch ros2_control_demo_bringup test_forward_position_controller.launch.py
+   ```
 
 ### Example 2: "Industrial Robots with only one interface" (Gazebo simulation)
 

--- a/ros2_control_demo_bringup/config/rrbot_gazebo_forward_controller_position.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_gazebo_forward_controller_position.yaml
@@ -8,9 +8,21 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
+    forward_position_controller:
+      type: forward_command_controller/ForwardCommandController
+
+
+forward_position_controller:
+  ros__parameters:
+    joints:
+      - joint1
+      - joint2
+    interface_name: position
+
 joint_trajectory_controller:
   ros__parameters:
     joints:
       - joint1
       - joint2
     interface_name: position
+

--- a/ros2_control_demo_bringup/config/rrbot_gazebo_forward_controller_position.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_gazebo_forward_controller_position.yaml
@@ -25,4 +25,3 @@ joint_trajectory_controller:
       - joint1
       - joint2
     interface_name: position
-

--- a/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from ament_index_python.packages import get_package_share_directory
+
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -38,10 +40,18 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "use_fake_hardware",
+            default_value="false",
+            description="Start robot with fake hardware mirroring command to its states.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "use_sim",
             default_value="true",
             description="Start robot with fake hardware mirroring command to its states.",
         )
     )
+
     declared_arguments.append(
         DeclareLaunchArgument(
             "fake_sensor_commands",
@@ -66,6 +76,7 @@ def generate_launch_description():
     # Initialize Arguments
     prefix = LaunchConfiguration("prefix")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    use_sim = LaunchConfiguration("use_sim")
     fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
     slowdown = LaunchConfiguration("slowdown")
     robot_controller = LaunchConfiguration("robot_controller")
@@ -73,13 +84,9 @@ def generate_launch_description():
     gazebo = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             [
-                PathJoinSubstitution(
-                    [
-                        FindPackageShare("gazebo_ros"),
-                        "launch",
-                        "gazebo.launch.py",
-                    ]
-                )
+                os.path.join(
+                    get_package_share_directory('gazebo_ros'),
+                    'launch'), '/gazebo.launch.py'
             ]
         ),
         launch_arguments={"verbose": "false"}.items(),
@@ -100,6 +107,7 @@ def generate_launch_description():
             "description_file": "rrbot_system_position_only.urdf.xacro",
             "prefix": prefix,
             "use_fake_hardware": use_fake_hardware,
+            "use_sim": use_sim,
             "fake_sensor_commands": fake_sensor_commands,
             "slowdown": slowdown,
             "robot_controller": robot_controller,

--- a/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
@@ -17,10 +17,9 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration
 
 from launch_ros.actions import Node
-from launch_ros.substitutions import FindPackageShare
 
 import os
 
@@ -84,9 +83,8 @@ def generate_launch_description():
     gazebo = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             [
-                os.path.join(
-                    get_package_share_directory('gazebo_ros'),
-                    'launch'), '/gazebo.launch.py'
+                os.path.join(get_package_share_directory("gazebo_ros"), "launch"),
+                "/gazebo.launch.py",
             ]
         ),
         launch_arguments={"verbose": "false"}.items(),

--- a/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
@@ -38,13 +38,6 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "use_fake_hardware",
-            default_value="false",
-            description="Start robot with fake hardware mirroring command to its states.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
             "use_sim",
             default_value="true",
             description="Start robot with fake hardware mirroring command to its states.",
@@ -74,7 +67,6 @@ def generate_launch_description():
 
     # Initialize Arguments
     prefix = LaunchConfiguration("prefix")
-    use_fake_hardware = LaunchConfiguration("use_fake_hardware")
     use_sim = LaunchConfiguration("use_sim")
     fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
     slowdown = LaunchConfiguration("slowdown")
@@ -104,7 +96,6 @@ def generate_launch_description():
         launch_arguments={
             "description_file": "rrbot_system_position_only.urdf.xacro",
             "prefix": prefix,
-            "use_fake_hardware": use_fake_hardware,
             "use_sim": use_sim,
             "fake_sensor_commands": fake_sensor_commands,
             "slowdown": slowdown,

--- a/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
@@ -12,16 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 
 from launch_ros.actions import Node
-
-import os
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
@@ -40,16 +37,7 @@ def generate_launch_description():
         DeclareLaunchArgument(
             "use_sim",
             default_value="true",
-            description="Start robot with fake hardware mirroring command to its states.",
-        )
-    )
-
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "fake_sensor_commands",
-            default_value="false",
-            description="Enable fake command interfaces for sensors used for simple simulations. \
-            Used only if 'use_fake_hardware' parameter is true.",
+            description="Start robot with simulation from Gazebo.",
         )
     )
     declared_arguments.append(
@@ -68,15 +56,19 @@ def generate_launch_description():
     # Initialize Arguments
     prefix = LaunchConfiguration("prefix")
     use_sim = LaunchConfiguration("use_sim")
-    fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
     slowdown = LaunchConfiguration("slowdown")
     robot_controller = LaunchConfiguration("robot_controller")
 
     gazebo = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             [
-                os.path.join(get_package_share_directory("gazebo_ros"), "launch"),
-                "/gazebo.launch.py",
+                PathJoinSubstitution(
+                    [
+                        FindPackageShare("gazebo_ros"),
+                        "launch",
+                        "gazebo.launch.py",
+                    ]
+                )
             ]
         ),
         launch_arguments={"verbose": "false"}.items(),
@@ -91,13 +83,20 @@ def generate_launch_description():
 
     base_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            [os.path.dirname(os.path.realpath(__file__)), "/rrbot.launch.py"]
+            [
+                PathJoinSubstitution(
+                    [
+                        FindPackageShare("ros2_control_demo_bringup"),
+                        "launch",
+                        "rrbot.launch.py",
+                    ]
+                )
+            ]
         ),
         launch_arguments={
             "description_file": "rrbot_system_position_only.urdf.xacro",
             "prefix": prefix,
             "use_sim": use_sim,
-            "fake_sensor_commands": fake_sensor_commands,
             "slowdown": slowdown,
             "robot_controller": robot_controller,
         }.items(),


### PR DESCRIPTION
The important point is to use the use_sim parameter when loading the URDF.
To make the forward_position_controller working I added some information missing in the yaml file.

Updated the README.md file for the targeted test. 

The other launch files were not tested.