### PR TITLE
Fix style

### DIFF
--- a/ros2_control_demo_bringup/launch/diffbot_system.launch.py
+++ b/ros2_control_demo_bringup/launch/diffbot_system.launch.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
-from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.conditions import IfCondition
@@ -45,16 +41,16 @@ def generate_launch_description():
         ]
     )
     robot_description = {"robot_description": robot_description_content}
-    robot_description_path = os.path.join(
-        get_package_share_directory("diffbot_description"),
+    robot_description_path = PathJoinSubstitution(
+        FindPackageShare("diffbot_description"),
         "urdf",
         "diffbot_system.urdf.xacro",
     )
     robot_description_config = xacro.process_file(robot_description_path)
     robot_description = {"robot_description": robot_description_config.toxml()}
 
-    diffbot_diff_drive_controller = os.path.join(
-        get_package_share_directory("ros2_control_demo_bringup"),
+    diffbot_diff_drive_controller = PathJoinSubstitution(
+        FindPackageShare("ros2_control_demo_bringup"),
         "config",
         "diffbot_diff_drive_controller.yaml",
     )

--- a/ros2_control_demo_bringup/launch/diffbot_system.launch.py
+++ b/ros2_control_demo_bringup/launch/diffbot_system.launch.py
@@ -19,8 +19,6 @@ from launch.substitutions import Command, FindExecutable, LaunchConfiguration, P
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
-import xacro
-
 
 def generate_launch_description():
 
@@ -41,18 +39,13 @@ def generate_launch_description():
         ]
     )
     robot_description = {"robot_description": robot_description_content}
-    robot_description_path = PathJoinSubstitution(
-        FindPackageShare("diffbot_description"),
-        "urdf",
-        "diffbot_system.urdf.xacro",
-    )
-    robot_description_config = xacro.process_file(robot_description_path)
-    robot_description = {"robot_description": robot_description_config.toxml()}
 
     diffbot_diff_drive_controller = PathJoinSubstitution(
-        FindPackageShare("ros2_control_demo_bringup"),
-        "config",
-        "diffbot_diff_drive_controller.yaml",
+        [
+            FindPackageShare("ros2_control_demo_bringup"),
+            "config",
+            "diffbot_diff_drive_controller.yaml",
+        ]
     )
 
     node_robot_state_publisher = Node(

--- a/ros2_control_demo_bringup/launch/rrbot_system_position_only.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_position_only.launch.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
-from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
@@ -93,10 +90,12 @@ def generate_launch_description():
     )
     robot_description = {"robot_description": robot_description_content}
 
-    rrbot_controllers = os.path.join(
-        get_package_share_directory("ros2_control_demo_bringup"),
-        "config",
-        "rrbot_controllers.yaml",
+    rrbot_controllers = PathJoinSubstitution(
+        [
+            FindPackageShare("ros2_control_demo_bringup"),
+            "config",
+            "rrbot_controllers.yaml",
+        ]
     )
 
     node_robot_state_publisher = Node(

--- a/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
@@ -12,10 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-
-from ament_index_python.packages import get_package_share_directory
-
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
 from launch.substitutions import Command, FindExecutable, PathJoinSubstitution
@@ -29,7 +25,7 @@ def generate_launch_description():
     gazebo = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             [
-                os.path.join(get_package_share_directory("gazebo_ros"), "launch"),
+                PathJoinSubstitution(FindPackageShare("gazebo_ros"), "launch"),
                 "/gazebo.launch.py",
             ]
         ),

--- a/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
@@ -24,10 +24,7 @@ from launch_ros.substitutions import FindPackageShare
 def generate_launch_description():
     gazebo = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            [
-                PathJoinSubstitution(FindPackageShare("gazebo_ros"), "launch"),
-                "/gazebo.launch.py",
-            ]
+            [PathJoinSubstitution([FindPackageShare("gazebo_ros"), "launch", "gazebo.launch.py"])]
         ),
         launch_arguments={"verbose": "false"}.items(),
     )

--- a/ros2_control_demo_bringup/launch/test_forward_position_controller_launch.py
+++ b/ros2_control_demo_bringup/launch/test_forward_position_controller_launch.py
@@ -1,0 +1,44 @@
+# Copyright 2021 Stogl Robotics Consulting UG (haftungsbeschränkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    position_goals = PathJoinSubstitution(
+        [
+            FindPackageShare("ros2_control_demo_bringup"),
+            "config",
+            "rrbot_forward_position_publisher.yaml",
+        ]
+    )
+
+    return LaunchDescription(
+        [
+            Node(
+                package="ros2_control_test_nodes",
+                executable="publisher_forward_position_controller",
+                name="publisher_forward_position_controller",
+                parameters=[position_goals],
+                output={
+                    "stdout": "screen",
+                    "stderr": "screen",
+                },
+            )
+        ]
+    )


### PR DESCRIPTION
Goal:
====
This PR intends to fix style inconsistencies related to PR https://github.com/ros-controls/ros2_control_demos/pull/113 reported by @destogl 

Description:
=========
 * Proposes PathJoinSubstitution instead of os.path.join
 * Proposes FindPackageShare instead of FindPackageShare
 * As far as I understood the loading of rrbot_description from the xacro  file  in the diffbot this PR simplifies it.
 * Put back test_forward_position_controller_launch.py
 
Tests done on this PR:
=================
  *  ros2 launch ros2_control_demo_bringup diffbot_system.launch.py start_rviz:=True
  *  ros2 launch ros2_control_demo_bringup rrbot_system_position_only_gazebo.launch.py
  *  ros2 launch ros2_control_demo_bringup rrbot_system_position_only.launch.py start_rviz:=True

Still having issue https://github.com/ros-controls/ros2_controllers/issues/201 on docker.
