### PR TITLE
Add JTC publisher into demo node and show its usage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,17 @@ You should now see an orange box circling in `rviz2`.
 
 
 ## Controllers and moving hardware
+
 To move the robot you should load and start controllers.
 The `JointStateController` is used to publish the joint states to ROS topics.
-Direct joint commands are sent to this robot via the `ForwardCommandController`.
+Direct joint commands are sent to this robot via the `ForwardCommandController` and `JointTrajectoryController`.
 The sections below describe their usage.
 Check the [Results](##result) section on how to ensure that things went well.
+
+**NOTE**: Before doing any action with controllers check their state using command:
+```
+ros2 control list_controllers
+```
 
 
 ### JointStateController
@@ -267,7 +273,7 @@ Now you should also see the *RRbot* represented correctly in `rviz2`.
    forward_position_controller[forward_command_controller/ForwardCommandController] inactive
    ```
 
-2. Now start the controller:
+3. Now start the controller:
    ```
    ros2 control switch_controllers --start forward_position_controller
    ```
@@ -281,7 +287,7 @@ Now you should also see the *RRbot* represented correctly in `rviz2`.
    forward_position_controller[forward_command_controller/ForwardCommandController] active
    ```
 
-3. Send a command to the controller, either:
+4. Send a command to the controller, either:
 
    a. Manually using ros2 cli interface:
    ```
@@ -293,6 +299,42 @@ Now you should also see the *RRbot* represented correctly in `rviz2`.
    ```
    ros2 launch ros2_control_demo_bringup test_forward_position_controller.launch.py
    ```
+   You can adjust the goals in [rrbot_forward_position_publisher.yaml](ros2_control_demo_bringup/config/rrbot_forward_position_publisher.yaml).
+
+### Using JointTrajectoryController
+
+1. If you want to test hardware with `JointTrajectoryController` first load and configure a controller (not always needed):
+   ```
+   ros2 control load_controller position_trajectory_controller --set-state configure
+   ```
+   Check if the controller is loaded and configured properly:
+   ```
+   ros2 control list_controllers
+   ```
+   You should get the response:
+   ```
+   position_trajectory_controller[joint_trajectory_controller/JointTrajectoryController] inactive
+   ```
+
+2. Now start the controller (and stop other running contorller):
+   ```
+   ros2 control switch_controllers --stop forward_position_controller --start position_trajectory_controller
+   ```
+   Check if controllers are activated:
+   ```
+   ros2 control list_controllers
+   ```
+   You should get `active` in the response:
+   ```
+   joint_state_controller[joint_state_controller/JointStateController] active
+   position_trajectory_controller[joint_trajectory_controller/JointTrajectoryController] active
+   ```
+
+3. Send a command to the controller using demo node which sends two goals every 5 seconds in a loop:
+   ```
+   ros2 launch ros2_control_demo_bringup test_forward_position_controller.launch.py
+   ```
+   You can adjust the goals in [rrbot_joint_trajectory_publisher.yaml](ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher.yaml).
 
 ## Result
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The *RRBot* URDF files can be found in the `urdf` folder of `rrbot_description` 
    ```
 
 
-4. Check [Controllers and moving hardware](#Controlles-and-moving-hardware) section to move *RRBot*.
+4. Check [Controllers and moving hardware](#controllers-and-moving-hardware) section to move *RRBot*.
 
 ### Example 1: "Industrial Robots with only one interface"
 

--- a/ros2_control_demo_bringup/config/rrbot_controllers.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_controllers.yaml
@@ -11,9 +11,33 @@ controller_manager:
     position_trajectory_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
+
 forward_position_controller:
   ros__parameters:
     joints:
       - joint1
       - joint2
     interface_name: position
+
+
+position_trajectory_controller:
+  ros__parameters:
+    joints:
+      - joint1
+      - joint2
+
+    command_interfaces:
+      - position
+
+    state_interfaces:
+      - position
+
+    state_publish_rate: 200.0 # Defaults to 50
+    action_monitor_rate: 20.0 # Defaults to 20
+
+    allow_partial_joints_goal: false # Defaults to false
+    open_loop_control: true
+    allow_integration_in_goal_trajectories: true
+    constraints:
+      stopped_velocity_tolerance: 0.01 # Defaults to 0.01
+      goal_time: 0.0 # Defaults to 0.0 (start immediately)

--- a/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher.yaml
@@ -1,0 +1,15 @@
+publisher_joint_trajectory_controller:
+  ros__parameters:
+
+    controller_name: "position_trajectory_controller"
+    wait_sec_between_publish: 6
+
+    goal_names: ["pos1", "pos2", "pos3", "pos4"]
+    pos1: [0.785, 0.785]
+    pos2: [0, 0]
+    pos3: [-0.785, -0.785]
+    pos4: [0, 0]
+
+    joints:
+      - joint1
+      - joint2

--- a/ros2_control_demo_bringup/launch/test_joint_trajectory_controller.launch.py
+++ b/ros2_control_demo_bringup/launch/test_joint_trajectory_controller.launch.py
@@ -1,0 +1,44 @@
+# Copyright 2021 Stogl Robotics Consulting UG (haftungsbeschränkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    position_goals = PathJoinSubstitution(
+        [
+            FindPackageShare("ros2_control_demo_bringup"),
+            "config",
+            "rrbot_joint_trajectory_publisher.yaml",
+        ]
+    )
+
+    return LaunchDescription(
+        [
+            Node(
+                package="ros2_control_test_nodes",
+                executable="publisher_joint_trajectory_controller",
+                name="publisher_joint_trajectory_controller",
+                parameters=[position_goals],
+                output={
+                    "stdout": "screen",
+                    "stderr": "screen",
+                },
+            )
+        ]
+    )

--- a/ros2_control_test_nodes/ros2_control_test_nodes/publisher_joint_trajectory_controller.py
+++ b/ros2_control_test_nodes/ros2_control_test_nodes/publisher_joint_trajectory_controller.py
@@ -1,0 +1,90 @@
+# Copyright 2021 Stogl Robotics Consulting UG (haftungsbeschränkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from rclpy.node import Node
+from builtin_interfaces.msg import Duration
+
+from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
+
+
+class PublisherJointTrajectory(Node):
+    def __init__(self):
+        super().__init__("publisher_position_trajectory_controller")
+        # Declare all parameters
+        self.declare_parameter("controller_name", "position_trajectory_controller")
+        self.declare_parameter("wait_sec_between_publish", 6)
+        self.declare_parameter("goal_names", ["pos1", "pos2"])
+        self.declare_parameter("joints")
+
+        # Read parameters
+        controller_name = self.get_parameter("controller_name").value
+        wait_sec_between_publish = self.get_parameter("wait_sec_between_publish").value
+        goal_names = self.get_parameter("goal_names").value
+        self.joints = self.get_parameter("joints").value
+
+        if self.joints is None or len(self.joints) == 0:
+            raise Exception('"joints" parameter is not set!')
+
+        # Read all positions from parameters
+        self.goals = []
+        for name in goal_names:
+            self.declare_parameter(name)
+            goal = self.get_parameter(name).value
+            if goal is None or len(goal) == 0:
+                raise Exception(f'Values for goal "{name}" not set!')
+
+            float_goal = []
+            for value in goal:
+                float_goal.append(float(value))
+            self.goals.append(float_goal)
+
+        publish_topic = "/" + controller_name + "/" + "joint_trajectory"
+
+        self.get_logger().info(
+            'Publishing {} goals on topic "{}" every {} s'.format(
+                len(goal_names), publish_topic, wait_sec_between_publish
+            )
+        )
+
+        self.publisher_ = self.create_publisher(JointTrajectory, publish_topic, 1)
+        self.timer = self.create_timer(wait_sec_between_publish, self.timer_callback)
+        self.i = 0
+
+    def timer_callback(self):
+        traj = JointTrajectory()
+        traj.joint_names = self.joints
+        point = JointTrajectoryPoint()
+        point.positions = self.goals[self.i]
+        point.time_from_start = Duration(sec=4)
+
+        traj.points.append(point)
+        self.publisher_.publish(traj)
+
+        self.i += 1
+        self.i %= len(self.goals)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+
+    publisher_joint_trajectory = PublisherJointTrajectory()
+
+    rclpy.spin(publisher_joint_trajectory)
+    publisher_joint_trajectory.destroy_node()
+    rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_control_test_nodes/setup.py
+++ b/ros2_control_test_nodes/setup.py
@@ -50,6 +50,8 @@ Demo nodes for showing and testing functionalities of the ros2_control framework
         "console_scripts": [
             "publisher_forward_position_controller = \
                 ros2_control_test_nodes.publisher_forward_position_controller:main",
+            "publisher_joint_trajectory_controller = \
+                ros2_control_test_nodes.publisher_joint_trajectory_controller:main",
         ],
     },
 )


### PR DESCRIPTION
Replaces #90.﻿

This is moved from `add_demo_nodes` branch and tested with multiple different robots and simulations.