### PR TITLE
Improve docs and behavior on complex examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Available controllers:
 Moving the robot:
   - see below description of `forward_position_controller`
 
-Available launch-file options:
+Available launch file options:
   - `use_fake_hardware:=true` - start `FakeSystem` instead of hardware.
     This is a simple simulation that mimics joint command to their states.
     This is useful to test *ros2_control* integration and controllers without physical hardware.
@@ -391,20 +391,22 @@ Moving the robot:
   - when using velocity controller:
     ```
     ros2 topic pub /forward_velocity_controller/commands std_msgs/msg/Float64MultiArray "data:
-    - 0.5
-    - 0.5"
+    - 5
+    - 5"
     ```
 
   - when using acceleration controller
     ```
     ros2 topic pub /forward_acceleration_controller/commands std_msgs/msg/Float64MultiArray "data:
-    - 0.01
-    - 0.01"
+    - 10
+    - 10"
     ```
 
 Useful launch-file options:
-  - `robot_controller:=forward_position_controller` - start demo and spawnes position controller. Robot can be then controlled using `forward_position_controller` as described below.
-  - `robot_controller:=forward_acceleration_controller` - start demo and spawnes acceleration controller. Robot can be then controlled using `forward_position_controller` as described below.
+  - `robot_controller:=forward_position_controller` - starts demo and spawns position controller.
+    Robot can be then controlled using `forward_position_controller` as described below.
+  - `robot_controller:=forward_acceleration_controller` - starts demo and spawns acceleration controller.
+    Robot can be then controlled using `forward_acceleration_controller` as described below.
 
 
 ### Example 3: "Industrial robot with integrated sensor"

--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Each of the described example cases from the [roadmap](https://github.com/ros-co
 **NOTE**: Getting the following output in terminal is OK: `Warning: Invalid frame ID "odom" passed to canTransform argument target_frame - frame does not exist`.
           This happens because `joint_state_publisher_gui` node need some time to start.
 
+
 1. To start an example open a terminal, source your ROS2-workspace and execute a launch file with:
    ```
    ros2 launch ros2_control_demo_bringup <example_launch_file>
@@ -314,19 +315,31 @@ Each of the described example cases from the [roadmap](https://github.com/ros-co
 1. Check [Controllers and moving hardware](#controllers-and-moving-hardware) section to move *RRBot*.
 
 
+*NOTE:* The examples reuse the same, configurable base-launch file [`rrbot_base.launch.py`](ros2_control_demo_bringup/launch/rrbot_base.launch.py).
+This also demonstrates how launch files are usually reused for different scenarios when working with `ros2_control`.
+
+
 ### Example 1: "Industrial Robots with only one interface"
 
-- Launch file: rrbot_system_position_only.launch.py
-- Command interfaces:
-  - joint1/position
-  - joint2/position
-- State interfaces:
-  - joint1/position
-  - joint2/position
+Files:
+  - Launch file: [rrbot_system_position_only.launch.py](ros2_control_demo_bringup/launch/rrbot_system_position_only.launch.py)
+  - Controllers yaml: [rrbot_controllers.yaml](ros2_control_demo_bringup/config/rrbot_controllers.yaml)
+  - `ros2_control` URDF tag: [rrbot_system_position_only.ros2_control.xacro](ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_position_only.ros2_control.xacro)
+
+Interfaces:
+  - Command interfaces:
+    - joint1/position
+    - joint2/position
+  - State interfaces:
+    - joint1/position
+    - joint2/position
 
 Available controllers:
   - `joint_state_broadcaster[joint_state_broadcaster/JointStateBroadcaster]`
   - `forward_position_controller[forward_command_controller/ForwardCommandController]` (position)
+
+Moving the robot:
+  - see below description of `forward_position_controller`
 
 Available launch-file options:
   - `use_fake_hardware:=true` - start `FakeSystem` instead of hardware.
@@ -341,21 +354,26 @@ Available launch-file options:
 
 ### Example 2: "Robots with multiple interfaces"
 
-- Launch file: rrbot_system_multi_interface.launch.py
-- Command interfaces:
-  - joint1/position
-  - joint2/position
-  - joint1/velocity
-  - joint2/velocity
-  - joint1/acceleration
-  - joint2/acceleration
-- State interfaces:
-  - joint1/position
-  - joint2/position
-  - joint1/velocity
-  - joint2/velocity
-  - joint1/acceleration
-  - joint2/acceleration
+Files:
+  - Launch file: [rrbot_system_multi_interface.launch.py](ros2_control_demo_bringup/launch/rrbot_system_multi_interface.launch.py)
+  - Controllers yaml: [rrbot_multi_interface_forward_controllers.yaml](ros2_control_demo_bringup/config/rrbot_multi_interface_forward_controllers.yaml)
+  - `ros2_control` URDF tag: [rrbot_system_multi_interface.ros2_control.xacro](ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_multi_interface.ros2_control.xacro)
+
+Interfaces:
+  - Command interfaces:
+    - joint1/position
+    - joint2/position
+    - joint1/velocity
+    - joint2/velocity
+    - joint1/acceleration
+    - joint2/acceleration
+  - State interfaces:
+    - joint1/position
+    - joint2/position
+    - joint1/velocity
+    - joint2/velocity
+    - joint1/acceleration
+    - joint2/acceleration
 
 Available controllers:
   - `joint_state_broadcaster[joint_state_broadcaster/JointStateBroadcaster]`
@@ -368,6 +386,25 @@ Available controllers:
 Notes:
   - The example shows how to implement multi-interface robot hardware taking care about interfaces used.
     The two illegal controllers demonstrate how hardware interface declines faulty claims to access joint command interfaces.
+
+Moving the robot:
+  - when using velocity controller:
+    ```
+    ros2 topic pub /forward_velocity_controller/commands std_msgs/msg/Float64MultiArray "data:
+    - 0.5
+    - 0.5"
+    ```
+
+  - when using acceleration controller
+    ```
+    ros2 topic pub /forward_acceleration_controller/commands std_msgs/msg/Float64MultiArray "data:
+    - 0.01
+    - 0.01"
+    ```
+
+Useful launch-file options:
+  - `robot_controller:=forward_position_controller` - start demo and spawnes position controller. Robot can be then controlled using `forward_position_controller` as described below.
+  - `robot_controller:=forward_acceleration_controller` - start demo and spawnes acceleration controller. Robot can be then controlled using `forward_position_controller` as described below.
 
 
 ### Example 3: "Industrial robot with integrated sensor"

--- a/README.md
+++ b/README.md
@@ -384,7 +384,6 @@ Available controllers:
   - `forward_illegal2_controller[forward_command_controller/ForwardCommandController]`
 
 Notes:
-  - Wrench messages are not displayed properly in Rviz as NaN values are not handled in Rviz and FTS Broadcaster may send NaN values.
   - The example shows how to implement multi-interface robot hardware taking care about interfaces used.
     The two illegal controllers demonstrate how hardware interface declines faulty claims to access joint command interfaces.
 

--- a/README.md
+++ b/README.md
@@ -384,6 +384,7 @@ Available controllers:
   - `forward_illegal2_controller[forward_command_controller/ForwardCommandController]`
 
 Notes:
+  - Wrench messages are not displayed properly in Rviz as NaN values are not handled in Rviz and FTS Broadcaster may send NaN values.
   - The example shows how to implement multi-interface robot hardware taking care about interfaces used.
     The two illegal controllers demonstrate how hardware interface declines faulty claims to access joint command interfaces.
 

--- a/ros2_control_demo_bringup/config/diffbot_controllers.yaml
+++ b/ros2_control_demo_bringup/config/diffbot_controllers.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 100  # Hz
+    update_rate: 10  # Hz
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster

--- a/ros2_control_demo_bringup/config/rrbot_controllers.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_controllers.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 100  # Hz
+    update_rate: 10  # Hz
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster

--- a/ros2_control_demo_bringup/config/rrbot_multi_interface_forward_controllers.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_multi_interface_forward_controllers.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 2  # Hz
+    update_rate: 100  # Hz
 
     forward_position_controller:
       type: position_controllers/JointGroupPositionController

--- a/ros2_control_demo_bringup/launch/diffbot.launch.py
+++ b/ros2_control_demo_bringup/launch/diffbot.launch.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 from launch import LaunchDescription
+from launch.actions import RegisterEventHandler
+from launch.event_handlers import OnProcessExit
 from launch.substitutions import Command, FindExecutable, PathJoinSubstitution
 
 from launch_ros.actions import Node
@@ -71,22 +73,38 @@ def generate_launch_description():
 
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
-        executable="spawner.py",
+        executable="spawner",
         arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
     )
 
     robot_controller_spawner = Node(
         package="controller_manager",
-        executable="spawner.py",
+        executable="spawner",
         arguments=["diffbot_base_controller", "-c", "/controller_manager"],
+    )
+
+    # Delay rviz start after `joint_state_broadcaster`
+    delay_rviz_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[rviz_node],
+        )
+    )
+
+    # Delay start of robot_controller after `joint_state_broadcaster`
+    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[robot_controller_spawner],
+        )
     )
 
     nodes = [
         control_node,
         robot_state_pub_node,
-        rviz_node,
         joint_state_broadcaster_spawner,
-        robot_controller_spawner,
+        delay_rviz_after_joint_state_broadcaster_spawner,
+        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
     ]
 
     return LaunchDescription(nodes)

--- a/ros2_control_demo_bringup/launch/rrbot.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot.launch.py
@@ -14,6 +14,8 @@
 
 
 from launch import LaunchDescription
+from launch.actions import RegisterEventHandler
+from launch.event_handlers import OnProcessExit
 from launch.substitutions import Command, FindExecutable, PathJoinSubstitution
 
 from launch_ros.actions import Node
@@ -79,22 +81,38 @@ def generate_launch_description():
 
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
-        executable="spawner.py",
+        executable="spawner",
         arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
     )
 
     robot_controller_spawner = Node(
         package="controller_manager",
-        executable="spawner.py",
+        executable="spawner",
         arguments=["forward_position_controller", "-c", "/controller_manager"],
+    )
+
+    # Delay rviz start after `joint_state_broadcaster`
+    delay_rviz_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[rviz_node],
+        )
+    )
+
+    # Delay start of robot_controller after `joint_state_broadcaster`
+    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[robot_controller_spawner],
+        )
     )
 
     nodes = [
         control_node,
         robot_state_pub_node,
-        rviz_node,
         joint_state_broadcaster_spawner,
-        robot_controller_spawner,
+        delay_rviz_after_joint_state_broadcaster_spawner,
+        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
     ]
 
     return LaunchDescription(nodes)

--- a/ros2_control_demo_bringup/launch/rrbot_base.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_base.launch.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, RegisterEventHandler
 from launch.conditions import IfCondition
+from launch.event_handlers import OnProcessExit
 from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
 
 from launch_ros.actions import Node
@@ -181,22 +182,38 @@ def generate_launch_description():
 
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
-        executable="spawner.py",
+        executable="spawner",
         arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
     )
 
     robot_controller_spawner = Node(
         package="controller_manager",
-        executable="spawner.py",
+        executable="spawner",
         arguments=[robot_controller, "-c", "/controller_manager"],
+    )
+
+    # Delay rviz start after `joint_state_broadcaster`
+    delay_rviz_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[rviz_node],
+        )
+    )
+
+    # Delay start of robot_controller after `joint_state_broadcaster`
+    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=joint_state_broadcaster_spawner,
+            on_exit=[robot_controller_spawner],
+        )
     )
 
     nodes = [
         control_node,
         robot_state_pub_node,
-        rviz_node,
         joint_state_broadcaster_spawner,
-        robot_controller_spawner,
+        delay_rviz_after_joint_state_broadcaster_spawner,
+        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/ros2_control_demo_bringup/launch/rrbot_system_multi_interface.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_multi_interface.launch.py
@@ -32,36 +32,19 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "use_fake_hardware",
-            default_value="true",
-            description="Start robot with fake hardware mirroring command to its states.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "fake_sensor_commands",
-            default_value="false",
-            description="Enable fake command interfaces for sensors used for simple simulations. \
-            Used only if 'use_fake_hardware' parameter is true.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "slowdown", default_value="3.0", description="Slowdown factor of the RRbot."
+            "slowdown", default_value="50.0", description="Slowdown factor of the RRbot."
         )
     )
     declared_arguments.append(
         DeclareLaunchArgument(
             "robot_controller",
-            default_value="forward_position_controller",
+            default_value="forward_velocity_controller",
             description="Robot controller to start.",
         )
     )
 
     # Initialize Arguments
     prefix = LaunchConfiguration("prefix")
-    use_fake_hardware = LaunchConfiguration("use_fake_hardware")
-    fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
     slowdown = LaunchConfiguration("slowdown")
     robot_controller = LaunchConfiguration("robot_controller")
 
@@ -71,8 +54,8 @@ def generate_launch_description():
             "controllers_file": "rrbot_multi_interface_forward_controllers.yaml",
             "description_file": "rrbot_system_multi_interface.urdf.xacro",
             "prefix": prefix,
-            "use_fake_hardware": use_fake_hardware,
-            "fake_sensor_commands": fake_sensor_commands,
+            "use_fake_hardware": "false",
+            "fake_sensor_commands": "false",
             "slowdown": slowdown,
             "robot_controller": robot_controller,
         }.items(),

--- a/ros2_control_demo_bringup/launch/rrbot_system_position_only.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_position_only.launch.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Open Source Robotics Foundation, Inc.
+# Copyright 2021 Stogl Robotics Consulting UG (haftungsbeschränkt)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,27 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
-from launch.conditions import IfCondition
-from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
-
-from launch_ros.actions import Node
-from launch_ros.substitutions import FindPackageShare
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, ThisLaunchFileDir
 
 
 def generate_launch_description():
-
+    # Declare arguments
     declared_arguments = []
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "start_rviz",
-            default_value="false",
-            description="start RViz automatically with the launch file",
-        )
-    )
-
     declared_arguments.append(
         DeclareLaunchArgument(
             "prefix",
@@ -42,7 +30,6 @@ def generate_launch_description():
         have to be updated.",
         )
     )
-
     declared_arguments.append(
         DeclareLaunchArgument(
             "use_fake_hardware",
@@ -50,7 +37,6 @@ def generate_launch_description():
             description="Start robot with fake hardware mirroring command to its states.",
         )
     )
-
     declared_arguments.append(
         DeclareLaunchArgument(
             "fake_sensor_commands",
@@ -59,84 +45,45 @@ def generate_launch_description():
             Used only if 'use_fake_hardware' parameter is true.",
         )
     )
-
     declared_arguments.append(
         DeclareLaunchArgument(
-            "slowdown", default_value="3.0", description="Slowdown factor of the RRbot."
+            "slowdown", default_value="50.0", description="Slowdown factor of the RRbot."
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "robot_controller",
+            default_value="forward_position_controller",
+            description="Robot controller to start.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "start_rviz",
+            default_value="true",
+            description="Start RViz2 automatically with this launch file.",
         )
     )
 
-    # Get URDF via xacro
-    robot_description_content = Command(
-        [
-            PathJoinSubstitution([FindExecutable(name="xacro")]),
-            " ",
-            PathJoinSubstitution(
-                [
-                    FindPackageShare("rrbot_description"),
-                    "urdf",
-                    "rrbot_system_position_only.urdf.xacro",
-                ]
-            ),
-            " prefix:=",
-            LaunchConfiguration("prefix"),
-            " use_fake_hardware:=",
-            LaunchConfiguration("use_fake_hardware"),
-            " fake_sensor_commands:=",
-            LaunchConfiguration("fake_sensor_commands"),
-            " slowdown:=",
-            LaunchConfiguration("slowdown"),
-        ]
-    )
-    robot_description = {"robot_description": robot_description_content}
+    # Initialize Arguments
+    prefix = LaunchConfiguration("prefix")
+    use_fake_hardware = LaunchConfiguration("use_fake_hardware")
+    fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
+    slowdown = LaunchConfiguration("slowdown")
+    robot_controller = LaunchConfiguration("robot_controller")
+    start_rviz = LaunchConfiguration("start_rviz")
 
-    rrbot_controllers = PathJoinSubstitution(
-        [
-            FindPackageShare("ros2_control_demo_bringup"),
-            "config",
-            "rrbot_controllers.yaml",
-        ]
+    base_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([ThisLaunchFileDir(), "/rrbot_base.launch.py"]),
+        launch_arguments={
+            "description_file": "rrbot_system_position_only.urdf.xacro",
+            "prefix": prefix,
+            "use_fake_hardware": use_fake_hardware,
+            "fake_sensor_commands": fake_sensor_commands,
+            "slowdown": slowdown,
+            "robot_controller": robot_controller,
+            "start_rviz": start_rviz,
+        }.items(),
     )
 
-    node_robot_state_publisher = Node(
-        package="robot_state_publisher",
-        executable="robot_state_publisher",
-        output="screen",
-        parameters=[robot_description],
-    )
-
-    controller_manager_node = Node(
-        package="controller_manager",
-        executable="ros2_control_node",
-        parameters=[robot_description, rrbot_controllers],
-        output={
-            "stdout": "screen",
-            "stderr": "screen",
-        },
-    )
-
-    spawn_jsb_controller = Node(
-        package="controller_manager",
-        executable="spawner.py",
-        arguments=["joint_state_broadcaster"],
-        output="screen",
-    )
-
-    rviz_config_file = PathJoinSubstitution(
-        [FindPackageShare("rrbot_description"), "config", "rrbot.rviz"]
-    )
-    rviz_node = Node(
-        package="rviz2",
-        executable="rviz2",
-        name="rviz2",
-        arguments=["-d", rviz_config_file],
-        condition=IfCondition(LaunchConfiguration("start_rviz")),
-    )
-
-    nodes = [
-        controller_manager_node,
-        node_robot_state_publisher,
-        spawn_jsb_controller,
-        rviz_node,
-    ]
-    return LaunchDescription(declared_arguments + nodes)
+    return LaunchDescription(declared_arguments + [base_launch])

--- a/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
@@ -61,7 +61,7 @@ def generate_launch_description():
     )
     spawn_controller = Node(
         package="controller_manager",
-        executable="spawner.py",
+        executable="spawner",
         arguments=["joint_state_broadcaster"],
         output="screen",
     )

--- a/ros2_control_demo_bringup/launch/rrbot_system_with_external_sensor.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_with_external_sensor.launch.py
@@ -78,7 +78,7 @@ def generate_launch_description():
     # add the spawner node for the fts_broadcaster
     fts_broadcaster_spawner = Node(
         package="controller_manager",
-        executable="spawner.py",
+        executable="spawner",
         arguments=["fts_broadcaster", "--controller-manager", "/controller_manager"],
     )
 

--- a/ros2_control_demo_bringup/launch/rrbot_system_with_sensor.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_with_sensor.launch.py
@@ -77,7 +77,7 @@ def generate_launch_description():
     # add the spawner node for the fts_broadcaster
     fts_broadcaster_spawner = Node(
         package="controller_manager",
-        executable="spawner.py",
+        executable="spawner",
         arguments=["fts_broadcaster", "--controller-manager", "/controller_manager"],
     )
 

--- a/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_multi_interface.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_multi_interface.ros2_control.xacro
@@ -19,7 +19,7 @@
           </xacro:if>
           <xacro:unless value="${use_fake_hardware}">
             <plugin>ros2_control_demo_hardware/RRBotSystemMultiInterfaceHardware</plugin>
-            <param name="example_param_hw_start_duration_sec">2.0</param>
+            <param name="example_param_hw_start_duration_sec">0.0</param>
             <param name="example_param_hw_stop_duration_sec">3.0</param>
             <param name="example_param_hw_slowdown">${slowdown}</param>
           </xacro:unless>

--- a/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_position_only.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_position_only.ros2_control.xacro
@@ -19,7 +19,7 @@
           </xacro:if>
           <xacro:unless value="${use_fake_hardware}">
             <plugin>ros2_control_demo_hardware/RRBotSystemPositionOnlyHardware</plugin>
-            <param name="example_param_hw_start_duration_sec">2.0</param>
+            <param name="example_param_hw_start_duration_sec">0.0</param>
             <param name="example_param_hw_stop_duration_sec">3.0</param>
             <param name="example_param_hw_slowdown">${slowdown}</param>
           </xacro:unless>

--- a/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_multi_interface.urdf.xacro
+++ b/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_multi_interface.urdf.xacro
@@ -11,7 +11,7 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_desc
   <xacro:arg name="use_fake_hardware" default="false" />
   <xacro:arg name="fake_sensor_commands" default="false" />
   <xacro:arg name="prefix" default="" />
-  <xacro:arg name="slowdown" default="2.0" />
+  <xacro:arg name="slowdown" default="100.0" />
 
   <!-- Import RRBot macro -->
   <xacro:include filename="$(find rrbot_description)/urdf/rrbot_description.urdf.xacro" />

--- a/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_position_only.urdf.xacro
+++ b/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_position_only.urdf.xacro
@@ -11,7 +11,7 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_desc
   <xacro:arg name="use_fake_hardware" default="false" />
   <xacro:arg name="fake_sensor_commands" default="false" />
   <xacro:arg name="prefix" default="" />
-  <xacro:arg name="slowdown" default="2.0" />
+  <xacro:arg name="slowdown" default="100.0" />
 
   <!-- Import RRBot macro -->
   <xacro:include filename="$(find rrbot_description)/urdf/rrbot_description.urdf.xacro" />

--- a/ros2_control_demo_hardware/include/ros2_control_demo_hardware/rrbot_system_multi_interface.hpp
+++ b/ros2_control_demo_hardware/include/ros2_control_demo_hardware/rrbot_system_multi_interface.hpp
@@ -15,6 +15,7 @@
 #ifndef ROS2_CONTROL_DEMO_HARDWARE__RRBOT_SYSTEM_MULTI_INTERFACE_HPP_
 #define ROS2_CONTROL_DEMO_HARDWARE__RRBOT_SYSTEM_MULTI_INTERFACE_HPP_
 
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -74,9 +75,13 @@ private:
   std::vector<double> hw_commands_positions_;
   std::vector<double> hw_commands_velocities_;
   std::vector<double> hw_commands_accelerations_;
-  std::vector<double> hw_positions_;
-  std::vector<double> hw_velocities_;
-  std::vector<double> hw_accelerations_;
+  std::vector<double> hw_states_positions_;
+  std::vector<double> hw_states_velocities_;
+  std::vector<double> hw_states_accelerations_;
+
+  // Store time between update loops
+  std::chrono::time_point<std::chrono::system_clock> last_timestamp_;
+  std::chrono::duration<double> duration;  // Avoid initialization on each read
 
   // Enum defining at which control level we are
   // Dumb way of maintaining the command_interface type per joint.

--- a/ros2_control_demo_hardware/include/ros2_control_demo_hardware/rrbot_system_multi_interface.hpp
+++ b/ros2_control_demo_hardware/include/ros2_control_demo_hardware/rrbot_system_multi_interface.hpp
@@ -25,7 +25,10 @@
 #include "hardware_interface/hardware_info.hpp"
 #include "hardware_interface/system_interface.hpp"
 #include "hardware_interface/types/hardware_interface_return_values.hpp"
+#include "rclcpp/clock.hpp"
+#include "rclcpp/duration.hpp"
 #include "rclcpp/macros.hpp"
+#include "rclcpp/time.hpp"
 #include "rclcpp_lifecycle/node_interfaces/lifecycle_node_interface.hpp"
 #include "rclcpp_lifecycle/state.hpp"
 #include "ros2_control_demo_hardware/visibility_control.h"
@@ -80,8 +83,9 @@ private:
   std::vector<double> hw_states_accelerations_;
 
   // Store time between update loops
-  std::chrono::time_point<std::chrono::system_clock> last_timestamp_;
-  std::chrono::duration<double> duration;  // Avoid initialization on each read
+  rclcpp::Clock clock_;
+  rclcpp::Time last_timestamp_;
+  rclcpp::Time current_timestamp;  // Avoid initialization on each read
 
   // Enum defining at which control level we are
   // Dumb way of maintaining the command_interface type per joint.

--- a/ros2_control_demo_hardware/src/diffbot_system.cpp
+++ b/ros2_control_demo_hardware/src/diffbot_system.cpp
@@ -36,8 +36,10 @@ CallbackReturn DiffBotSystemHardware::on_init(const hardware_interface::Hardware
     return CallbackReturn::ERROR;
   }
 
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   hw_start_sec_ = stod(info_.hardware_parameters["example_param_hw_start_duration_sec"]);
   hw_stop_sec_ = stod(info_.hardware_parameters["example_param_hw_stop_duration_sec"]);
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
   hw_positions_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
   hw_velocities_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
   hw_commands_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
@@ -123,7 +125,8 @@ std::vector<hardware_interface::CommandInterface> DiffBotSystemHardware::export_
 CallbackReturn DiffBotSystemHardware::on_activate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  RCLCPP_INFO(rclcpp::get_logger("DiffBotSystemHardware"), "Starting ...please wait...");
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
+  RCLCPP_INFO(rclcpp::get_logger("DiffBotSystemHardware"), "Activating ...please wait...");
 
   for (auto i = 0; i < hw_start_sec_; i++)
   {
@@ -131,6 +134,7 @@ CallbackReturn DiffBotSystemHardware::on_activate(
     RCLCPP_INFO(
       rclcpp::get_logger("DiffBotSystemHardware"), "%.1f seconds left...", hw_start_sec_ - i);
   }
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   // set some default values
   for (auto i = 0u; i < hw_positions_.size(); i++)
@@ -143,7 +147,7 @@ CallbackReturn DiffBotSystemHardware::on_activate(
     }
   }
 
-  RCLCPP_INFO(rclcpp::get_logger("DiffBotSystemHardware"), "System Successfully started!");
+  RCLCPP_INFO(rclcpp::get_logger("DiffBotSystemHardware"), "Successfully activated!");
 
   return CallbackReturn::SUCCESS;
 }
@@ -151,7 +155,8 @@ CallbackReturn DiffBotSystemHardware::on_activate(
 CallbackReturn DiffBotSystemHardware::on_deactivate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  RCLCPP_INFO(rclcpp::get_logger("DiffBotSystemHardware"), "Stopping ...please wait...");
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
+  RCLCPP_INFO(rclcpp::get_logger("DiffBotSystemHardware"), "Deactivating ...please wait...");
 
   for (auto i = 0; i < hw_stop_sec_; i++)
   {
@@ -159,8 +164,9 @@ CallbackReturn DiffBotSystemHardware::on_deactivate(
     RCLCPP_INFO(
       rclcpp::get_logger("DiffBotSystemHardware"), "%.1f seconds left...", hw_stop_sec_ - i);
   }
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
-  RCLCPP_INFO(rclcpp::get_logger("DiffBotSystemHardware"), "System successfully stopped!");
+  RCLCPP_INFO(rclcpp::get_logger("DiffBotSystemHardware"), "Successfully deactivated!");
 
   return CallbackReturn::SUCCESS;
 }
@@ -180,10 +186,12 @@ hardware_interface::return_type DiffBotSystemHardware::read()
     hw_positions_[i] = hw_positions_[1] + dt * hw_commands_[i];
     hw_velocities_[i] = hw_commands_[i];
 
+    // START: This part here is for exemplary purposes - Please do not copy to your production code
     RCLCPP_INFO(
       rclcpp::get_logger("DiffBotSystemHardware"),
       "Got position state %.5f and velocity state %.5f for '%s'!", hw_positions_[i],
       hw_velocities_[i], info_.joints[i].name.c_str());
+    // END: This part here is for exemplary purposes - Please do not copy to your production code
   }
 
   // Update the free-flyer, i.e. the base notation using the classical
@@ -195,15 +203,18 @@ hardware_interface::return_type DiffBotSystemHardware::read()
   base_y_ += base_dy * dt;
   base_theta_ += base_dtheta * dt;
 
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(
     rclcpp::get_logger("DiffBotSystemHardware"), "Joints successfully read! (%.5f,%.5f,%.5f)",
     base_x_, base_y_, base_theta_);
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   return hardware_interface::return_type::OK;
 }
 
 hardware_interface::return_type ros2_control_demo_hardware::DiffBotSystemHardware::write()
 {
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(rclcpp::get_logger("DiffBotSystemHardware"), "Writing...");
 
   for (auto i = 0u; i < hw_commands_.size(); i++)
@@ -214,6 +225,7 @@ hardware_interface::return_type ros2_control_demo_hardware::DiffBotSystemHardwar
       info_.joints[i].name.c_str());
   }
   RCLCPP_INFO(rclcpp::get_logger("DiffBotSystemHardware"), "Joints successfully written!");
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   return hardware_interface::return_type::OK;
 }

--- a/ros2_control_demo_hardware/src/external_rrbot_force_torque_sensor.cpp
+++ b/ros2_control_demo_hardware/src/external_rrbot_force_torque_sensor.cpp
@@ -37,9 +37,11 @@ CallbackReturn ExternalRRBotForceTorqueSensorHardware::on_init(
     return CallbackReturn::ERROR;
   }
 
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   hw_start_sec_ = stod(info_.hardware_parameters["example_param_hw_start_duration_sec"]);
   hw_stop_sec_ = stod(info_.hardware_parameters["example_param_hw_stop_duration_sec"]);
   hw_sensor_change_ = stod(info_.hardware_parameters["example_param_max_sensor_change"]);
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   hw_sensor_states_.resize(
     info_.sensors[0].state_interfaces.size(), std::numeric_limits<double>::quiet_NaN());
@@ -65,8 +67,9 @@ ExternalRRBotForceTorqueSensorHardware::export_state_interfaces()
 CallbackReturn ExternalRRBotForceTorqueSensorHardware::on_activate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(
-    rclcpp::get_logger("ExternalRRBotForceTorqueSensorHardware"), "Starting ...please wait...");
+    rclcpp::get_logger("ExternalRRBotForceTorqueSensorHardware"), "Activating ...please wait...");
 
   for (int i = 0; i < hw_start_sec_; i++)
   {
@@ -77,7 +80,8 @@ CallbackReturn ExternalRRBotForceTorqueSensorHardware::on_activate(
   }
 
   RCLCPP_INFO(
-    rclcpp::get_logger("ExternalRRBotForceTorqueSensorHardware"), "System Successfully started!");
+    rclcpp::get_logger("ExternalRRBotForceTorqueSensorHardware"), "Successfully activated!");
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   return CallbackReturn::SUCCESS;
 }
@@ -85,8 +89,9 @@ CallbackReturn ExternalRRBotForceTorqueSensorHardware::on_activate(
 CallbackReturn ExternalRRBotForceTorqueSensorHardware::on_deactivate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(
-    rclcpp::get_logger("ExternalRRBotForceTorqueSensorHardware"), "Stopping ...please wait...");
+    rclcpp::get_logger("ExternalRRBotForceTorqueSensorHardware"), "Deactivating ...please wait...");
 
   for (int i = 0; i < hw_stop_sec_; i++)
   {
@@ -97,13 +102,15 @@ CallbackReturn ExternalRRBotForceTorqueSensorHardware::on_deactivate(
   }
 
   RCLCPP_INFO(
-    rclcpp::get_logger("ExternalRRBotForceTorqueSensorHardware"), "System successfully stopped!");
+    rclcpp::get_logger("ExternalRRBotForceTorqueSensorHardware"), "Successfully deactivated!");
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   return CallbackReturn::SUCCESS;
 }
 
 hardware_interface::return_type ExternalRRBotForceTorqueSensorHardware::read()
 {
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(rclcpp::get_logger("ExternalRRBotForceTorqueSensorHardware"), "Reading...");
 
   for (uint i = 0; i < hw_sensor_states_.size(); i++)
@@ -118,6 +125,7 @@ hardware_interface::return_type ExternalRRBotForceTorqueSensorHardware::read()
   }
   RCLCPP_INFO(
     rclcpp::get_logger("ExternalRRBotForceTorqueSensorHardware"), "Joints successfully read!");
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   return hardware_interface::return_type::OK;
 }

--- a/ros2_control_demo_hardware/src/rrbot_actuator.cpp
+++ b/ros2_control_demo_hardware/src/rrbot_actuator.cpp
@@ -36,10 +36,11 @@ CallbackReturn RRBotModularJoint::on_init(const hardware_interface::HardwareInfo
   {
     return CallbackReturn::ERROR;
   }
-
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   hw_start_sec_ = stod(info_.hardware_parameters["example_param_hw_start_duration_sec"]);
   hw_stop_sec_ = stod(info_.hardware_parameters["example_param_hw_stop_duration_sec"]);
   hw_slowdown_ = stod(info_.hardware_parameters["example_param_hw_slowdown"]);
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   hw_joint_state_ = std::numeric_limits<double>::quiet_NaN();
   hw_joint_command_ = std::numeric_limits<double>::quiet_NaN();
@@ -106,13 +107,15 @@ std::vector<hardware_interface::CommandInterface> RRBotModularJoint::export_comm
 
 CallbackReturn RRBotModularJoint::on_activate(const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  RCLCPP_INFO(rclcpp::get_logger("RRBotModularJoint"), "Starting ...please wait...");
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
+  RCLCPP_INFO(rclcpp::get_logger("RRBotModularJoint"), "Activating ...please wait...");
 
   for (int i = 0; i < hw_start_sec_; i++)
   {
     rclcpp::sleep_for(std::chrono::seconds(1));
     RCLCPP_INFO(rclcpp::get_logger("RRBotModularJoint"), "%.1f seconds left...", hw_start_sec_ - i);
   }
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   // set some default values for joints
   if (std::isnan(hw_joint_state_))
@@ -121,14 +124,15 @@ CallbackReturn RRBotModularJoint::on_activate(const rclcpp_lifecycle::State & /*
     hw_joint_command_ = 0;
   }
 
-  RCLCPP_INFO(rclcpp::get_logger("RRBotModularJoint"), "System Successfully started!");
+  RCLCPP_INFO(rclcpp::get_logger("RRBotModularJoint"), "Successfully activated!");
 
   return CallbackReturn::SUCCESS;
 }
 
 CallbackReturn RRBotModularJoint::on_deactivate(const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  RCLCPP_INFO(rclcpp::get_logger("RRBotModularJoint"), "Stopping ...please wait...");
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
+  RCLCPP_INFO(rclcpp::get_logger("RRBotModularJoint"), "Deactivating ...please wait...");
 
   for (int i = 0; i < hw_stop_sec_; i++)
   {
@@ -136,13 +140,15 @@ CallbackReturn RRBotModularJoint::on_deactivate(const rclcpp_lifecycle::State & 
     RCLCPP_INFO(rclcpp::get_logger("RRBotModularJoint"), "%.1f seconds left...", hw_stop_sec_ - i);
   }
 
-  RCLCPP_INFO(rclcpp::get_logger("RRBotModularJoint"), "System successfully stopped!");
+  RCLCPP_INFO(rclcpp::get_logger("RRBotModularJoint"), "Successfully deactivated!");
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   return CallbackReturn::SUCCESS;
 }
 
 hardware_interface::return_type RRBotModularJoint::read()
 {
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(rclcpp::get_logger("RRBotModularJoint"), "Reading...");
 
   // Simulate RRBot's movement
@@ -152,12 +158,14 @@ hardware_interface::return_type RRBotModularJoint::read()
     info_.joints[0].name.c_str());
 
   RCLCPP_INFO(rclcpp::get_logger("RRBotModularJoint"), "Joints successfully read!");
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   return hardware_interface::return_type::OK;
 }
 
 hardware_interface::return_type ros2_control_demo_hardware::RRBotModularJoint::write()
 {
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(rclcpp::get_logger("RRBotModularJoint"), "Writing...please wait...");
 
   // Simulate sending commands to the hardware
@@ -166,6 +174,7 @@ hardware_interface::return_type ros2_control_demo_hardware::RRBotModularJoint::w
     info_.joints[0].name.c_str());
 
   RCLCPP_INFO(rclcpp::get_logger("RRBotModularJoint"), "Joints successfully written!");
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   return hardware_interface::return_type::OK;
 }

--- a/ros2_control_demo_hardware/src/rrbot_system_multi_interface.cpp
+++ b/ros2_control_demo_hardware/src/rrbot_system_multi_interface.cpp
@@ -34,9 +34,11 @@ CallbackReturn RRBotSystemMultiInterfaceHardware::on_init(
     return CallbackReturn::ERROR;
   }
 
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   hw_start_sec_ = stod(info_.hardware_parameters["example_param_hw_start_duration_sec"]);
   hw_stop_sec_ = stod(info_.hardware_parameters["example_param_hw_stop_duration_sec"]);
   hw_slowdown_ = stod(info_.hardware_parameters["example_param_hw_slowdown"]);
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
   hw_states_positions_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
   hw_states_velocities_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
   hw_states_accelerations_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
@@ -196,6 +198,7 @@ hardware_interface::return_type RRBotSystemMultiInterfaceHardware::prepare_comma
 CallbackReturn RRBotSystemMultiInterfaceHardware::on_activate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(
     rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"), "Starting... please wait...");
 
@@ -206,6 +209,7 @@ CallbackReturn RRBotSystemMultiInterfaceHardware::on_activate(
       rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"), "%.1f seconds left...",
       hw_start_sec_ - i);
   }
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   // Set some default values
   for (std::size_t i = 0; i < hw_states_positions_.size(); i++)
@@ -248,6 +252,7 @@ CallbackReturn RRBotSystemMultiInterfaceHardware::on_activate(
 CallbackReturn RRBotSystemMultiInterfaceHardware::on_deactivate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(
     rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"), "Stopping... please wait...");
 
@@ -259,8 +264,8 @@ CallbackReturn RRBotSystemMultiInterfaceHardware::on_deactivate(
       hw_stop_sec_ - i);
   }
 
-  RCLCPP_INFO(
-    rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"), "System successfully stopped!");
+  RCLCPP_INFO(rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"), "Successfully deactivated!");
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   return CallbackReturn::SUCCESS;
 }
@@ -279,33 +284,36 @@ hardware_interface::return_type RRBotSystemMultiInterfaceHardware::read()
           "Nothing is using the hardware interface!");
         return hardware_interface::return_type::OK;
         break;
-      case integration_lvl_t::POSITION:
+      case integration_level_t::POSITION:
         hw_states_accelerations_[i] = 0;
         hw_states_velocities_[i] = 0;
         hw_states_positions_[i] +=
           (hw_commands_positions_[i] - hw_states_positions_[i]) / hw_slowdown_;
         break;
-      case integration_lvl_t::VELOCITY:
+      case integration_level_t::VELOCITY:
         hw_states_accelerations_[i] = 0;
         hw_states_velocities_[i] = hw_commands_velocities_[i];
         hw_states_positions_[i] += (hw_states_velocities_[i] * duration.count()) / hw_slowdown_;
         break;
-      case integration_lvl_t::ACCELERATION:
+      case integration_level_t::ACCELERATION:
         hw_states_accelerations_[i] = hw_commands_accelerations_[i];
         hw_states_velocities_[i] += (hw_states_accelerations_[i] * duration.count()) / hw_slowdown_;
         hw_states_positions_[i] += (hw_states_velocities_[i] * duration.count()) / hw_slowdown_;
         break;
     }
+    // START: This part here is for exemplary purposes - Please do not copy to your production code
     RCLCPP_INFO(
       rclcpp::get_logger("RRBotSystemMultiInterfaceHardware"),
       "Got pos: %.5f, vel: %.5f, acc: %.5f for joint %lu!", hw_states_positions_[i],
       hw_states_velocities_[i], hw_states_accelerations_[i], i);
+    // END: This part here is for exemplary purposes - Please do not copy to your production code
   }
   return hardware_interface::return_type::OK;
 }
 
 hardware_interface::return_type RRBotSystemMultiInterfaceHardware::write()
 {
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   for (std::size_t i = 0; i < hw_commands_positions_.size(); i++)
   {
     // Simulate sending commands to the hardware
@@ -315,6 +323,8 @@ hardware_interface::return_type RRBotSystemMultiInterfaceHardware::write()
       hw_commands_positions_[i], hw_commands_velocities_[i], hw_commands_accelerations_[i], i,
       control_level_[i]);
   }
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
+
   return hardware_interface::return_type::OK;
 }
 

--- a/ros2_control_demo_hardware/src/rrbot_system_position_only.cpp
+++ b/ros2_control_demo_hardware/src/rrbot_system_position_only.cpp
@@ -33,9 +33,11 @@ CallbackReturn RRBotSystemPositionOnlyHardware::on_init(
     return CallbackReturn::ERROR;
   }
 
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   hw_start_sec_ = stod(info_.hardware_parameters["example_param_hw_start_duration_sec"]);
   hw_stop_sec_ = stod(info_.hardware_parameters["example_param_hw_stop_duration_sec"]);
   hw_slowdown_ = stod(info_.hardware_parameters["example_param_hw_slowdown"]);
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
   hw_states_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
   hw_commands_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
 
@@ -85,6 +87,7 @@ CallbackReturn RRBotSystemPositionOnlyHardware::on_init(
 CallbackReturn RRBotSystemPositionOnlyHardware::on_configure(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(
     rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Configuring ...please wait...");
 
@@ -95,6 +98,7 @@ CallbackReturn RRBotSystemPositionOnlyHardware::on_configure(
       rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "%.1f seconds left...",
       hw_start_sec_ - i);
   }
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   // reset values always when configuring hardware
   for (uint i = 0; i < hw_states_.size(); i++)
@@ -103,8 +107,7 @@ CallbackReturn RRBotSystemPositionOnlyHardware::on_configure(
     hw_commands_[i] = 0;
   }
 
-  RCLCPP_INFO(
-    rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "System Successfully configured!");
+  RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Successfully configured!");
 
   return CallbackReturn::SUCCESS;
 }
@@ -138,7 +141,9 @@ RRBotSystemPositionOnlyHardware::export_command_interfaces()
 CallbackReturn RRBotSystemPositionOnlyHardware::on_activate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Starting ...please wait...");
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
+  RCLCPP_INFO(
+    rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Activating ...please wait...");
 
   for (int i = 0; i < hw_start_sec_; i++)
   {
@@ -147,6 +152,7 @@ CallbackReturn RRBotSystemPositionOnlyHardware::on_activate(
       rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "%.1f seconds left...",
       hw_start_sec_ - i);
   }
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   // command and state should be equal when starting
   for (uint i = 0; i < hw_states_.size(); i++)
@@ -154,8 +160,7 @@ CallbackReturn RRBotSystemPositionOnlyHardware::on_activate(
     hw_commands_[i] = hw_states_[i];
   }
 
-  RCLCPP_INFO(
-    rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "System Successfully started!");
+  RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Successfully activated!");
 
   return CallbackReturn::SUCCESS;
 }
@@ -163,7 +168,9 @@ CallbackReturn RRBotSystemPositionOnlyHardware::on_activate(
 CallbackReturn RRBotSystemPositionOnlyHardware::on_deactivate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Stopping ...please wait...");
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
+  RCLCPP_INFO(
+    rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Deactivating ...please wait...");
 
   for (int i = 0; i < hw_stop_sec_; i++)
   {
@@ -173,14 +180,15 @@ CallbackReturn RRBotSystemPositionOnlyHardware::on_deactivate(
       hw_stop_sec_ - i);
   }
 
-  RCLCPP_INFO(
-    rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "System successfully stopped!");
+  RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Successfully deactivated!");
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   return CallbackReturn::SUCCESS;
 }
 
 hardware_interface::return_type RRBotSystemPositionOnlyHardware::read()
 {
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Reading...");
 
   for (uint i = 0; i < hw_states_.size(); i++)
@@ -192,12 +200,14 @@ hardware_interface::return_type RRBotSystemPositionOnlyHardware::read()
       hw_states_[i], i);
   }
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Joints successfully read!");
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   return hardware_interface::return_type::OK;
 }
 
 hardware_interface::return_type RRBotSystemPositionOnlyHardware::write()
 {
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Writing...");
 
   for (uint i = 0; i < hw_commands_.size(); i++)
@@ -209,6 +219,7 @@ hardware_interface::return_type RRBotSystemPositionOnlyHardware::write()
   }
   RCLCPP_INFO(
     rclcpp::get_logger("RRBotSystemPositionOnlyHardware"), "Joints successfully written!");
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   return hardware_interface::return_type::OK;
 }

--- a/ros2_control_demo_hardware/src/rrbot_system_with_sensor.cpp
+++ b/ros2_control_demo_hardware/src/rrbot_system_with_sensor.cpp
@@ -36,10 +36,12 @@ CallbackReturn RRBotSystemWithSensorHardware::on_init(const hardware_interface::
     return CallbackReturn::ERROR;
   }
 
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   hw_start_sec_ = stod(info_.hardware_parameters["example_param_hw_start_duration_sec"]);
   hw_stop_sec_ = stod(info_.hardware_parameters["example_param_hw_stop_duration_sec"]);
   hw_slowdown_ = stod(info_.hardware_parameters["example_param_hw_slowdown"]);
   hw_sensor_change_ = stod(info_.hardware_parameters["example_param_max_sensor_change"]);
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   hw_joint_states_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
   hw_joint_commands_.resize(info_.joints.size(), std::numeric_limits<double>::quiet_NaN());
@@ -92,6 +94,7 @@ CallbackReturn RRBotSystemWithSensorHardware::on_init(const hardware_interface::
 CallbackReturn RRBotSystemWithSensorHardware::on_configure(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemWithSensorHardware"), "Configuring ...please wait...");
 
   for (int i = 0; i < hw_start_sec_; i++)
@@ -101,6 +104,7 @@ CallbackReturn RRBotSystemWithSensorHardware::on_configure(
       rclcpp::get_logger("RRBotSystemWithSensorHardware"), "%.1f seconds left...",
       hw_start_sec_ - i);
   }
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   // reset values always when configuring hardware
   for (uint i = 0; i < hw_joint_states_.size(); i++)
@@ -109,8 +113,7 @@ CallbackReturn RRBotSystemWithSensorHardware::on_configure(
     hw_joint_commands_[i] = 0;
   }
 
-  RCLCPP_INFO(
-    rclcpp::get_logger("RRBotSystemWithSensorHardware"), "System Successfully configured!");
+  RCLCPP_INFO(rclcpp::get_logger("RRBotSystemWithSensorHardware"), "Successfully configured!");
 
   return CallbackReturn::SUCCESS;
 }
@@ -151,7 +154,8 @@ RRBotSystemWithSensorHardware::export_command_interfaces()
 CallbackReturn RRBotSystemWithSensorHardware::on_activate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  RCLCPP_INFO(rclcpp::get_logger("RRBotSystemWithSensorHardware"), "Starting ...please wait...");
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
+  RCLCPP_INFO(rclcpp::get_logger("RRBotSystemWithSensorHardware"), "Activating ...please wait...");
 
   for (int i = 0; i < hw_start_sec_; i++)
   {
@@ -160,6 +164,7 @@ CallbackReturn RRBotSystemWithSensorHardware::on_activate(
       rclcpp::get_logger("RRBotSystemWithSensorHardware"), "%.1f seconds left...",
       hw_start_sec_ - i);
   }
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   // command and state should be equal when starting
   for (uint i = 0; i < hw_joint_states_.size(); i++)
@@ -173,7 +178,7 @@ CallbackReturn RRBotSystemWithSensorHardware::on_activate(
     hw_sensor_states_[0] = 0;
   }
 
-  RCLCPP_INFO(rclcpp::get_logger("RRBotSystemWithSensorHardware"), "System Successfully started!");
+  RCLCPP_INFO(rclcpp::get_logger("RRBotSystemWithSensorHardware"), "Successfully activated!");
 
   return CallbackReturn::SUCCESS;
 }
@@ -181,7 +186,9 @@ CallbackReturn RRBotSystemWithSensorHardware::on_activate(
 CallbackReturn RRBotSystemWithSensorHardware::on_deactivate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  RCLCPP_INFO(rclcpp::get_logger("RRBotSystemWithSensorHardware"), "Stopping ...please wait...");
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
+  RCLCPP_INFO(
+    rclcpp::get_logger("RRBotSystemWithSensorHardware"), "Deactivating ...please wait...");
 
   for (int i = 0; i < hw_stop_sec_; i++)
   {
@@ -191,13 +198,15 @@ CallbackReturn RRBotSystemWithSensorHardware::on_deactivate(
       hw_stop_sec_ - i);
   }
 
-  RCLCPP_INFO(rclcpp::get_logger("RRBotSystemWithSensorHardware"), "System successfully stopped!");
+  RCLCPP_INFO(rclcpp::get_logger("RRBotSystemWithSensorHardware"), "Successfully deactivated!");
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   return CallbackReturn::SUCCESS;
 }
 
 hardware_interface::return_type RRBotSystemWithSensorHardware::read()
 {
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemWithSensorHardware"), "Reading...please wait...");
 
   for (uint i = 0; i < hw_joint_states_.size(); i++)
@@ -222,12 +231,14 @@ hardware_interface::return_type RRBotSystemWithSensorHardware::read()
       hw_sensor_states_[i], info_.sensors[0].state_interfaces[i].name.c_str());
   }
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemWithSensorHardware"), "Sensors successfully read!");
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   return hardware_interface::return_type::OK;
 }
 
 hardware_interface::return_type ros2_control_demo_hardware::RRBotSystemWithSensorHardware::write()
 {
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemWithSensorHardware"), "Writing...please wait...");
 
   for (uint i = 0; i < hw_joint_commands_.size(); i++)
@@ -238,6 +249,7 @@ hardware_interface::return_type ros2_control_demo_hardware::RRBotSystemWithSenso
       hw_joint_commands_[i], i);
   }
   RCLCPP_INFO(rclcpp::get_logger("RRBotSystemWithSensorHardware"), "Joints successfully written!");
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   return hardware_interface::return_type::OK;
 }


### PR DESCRIPTION
sits on top #124

fourth part of #118 

Main changes:
- correct structure and header of "position only" example using rrbot_base.launch.py
- add links into README
- optimized behavior of multi interface example
- added start delay for rviz and controller spawner after JSB has been started. (This reduces warnings in output).
- added comments in the code what is exemplary-code to not be copied into production
- corrected nomenclarute: "start" --> "activate"; "stop" --> "deactivate"
