### PR TITLE
Add check of start state for trajectory publisher

### DIFF
--- a/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher.yaml
@@ -13,3 +13,8 @@ publisher_joint_trajectory_controller:
     joints:
       - joint1
       - joint2
+
+    check_starting_point: false
+    starting_point_limits:
+      joint1: [-0.1,0.1]
+      joint2: [-0.1,0.1]

--- a/ros2_control_test_nodes/ros2_control_test_nodes/publisher_joint_trajectory_controller.py
+++ b/ros2_control_test_nodes/ros2_control_test_nodes/publisher_joint_trajectory_controller.py
@@ -28,15 +28,15 @@ class PublisherJointTrajectory(Node):
         self.declare_parameter("wait_sec_between_publish", 6)
         self.declare_parameter("goal_names", ["pos1", "pos2"])
         self.declare_parameter("joints")
-        self.declare_parameter('check_starting_point', False)
-        self.declare_parameter('starting_point_limits')
+        self.declare_parameter("check_starting_point", False)
+        self.declare_parameter("starting_point_limits")
 
         # Read parameters
         controller_name = self.get_parameter("controller_name").value
         wait_sec_between_publish = self.get_parameter("wait_sec_between_publish").value
         goal_names = self.get_parameter("goal_names").value
         self.joints = self.get_parameter("joints").value
-        self.check_starting_point = self.get_parameter('check_starting_point').value
+        self.check_starting_point = self.get_parameter("check_starting_point").value
         self.starting_point = {}
 
         if self.joints is None or len(self.joints) == 0:
@@ -46,18 +46,16 @@ class PublisherJointTrajectory(Node):
         if self.check_starting_point:
             # declare nested params
             for name in self.joints:
-                param_name_tmp = 'starting_point_limits' + '.' + name
-                self.declare_parameter(param_name_tmp, [-2*3.14159, 2*3.14159])
+                param_name_tmp = "starting_point_limits" + "." + name
+                self.declare_parameter(param_name_tmp, [-2 * 3.14159, 2 * 3.14159])
                 self.starting_point[name] = self.get_parameter(param_name_tmp).value
 
             for name in self.joints:
                 if len(self.starting_point[name]) != 2:
                     raise Exception('"starting_point" parameter is not set correctly!')
             self.joint_state_sub = self.create_subscription(
-                JointState,
-                'joint_states',
-                self.joint_state_callback,
-                10)
+                JointState, "joint_states", self.joint_state_callback, 10
+            )
         self.starting_point_ok = not self.check_starting_point
         self.joint_state_msg_received = False
 
@@ -103,20 +101,23 @@ class PublisherJointTrajectory(Node):
             self.i %= len(self.goals)
 
         elif self.check_starting_point and not self.joint_state_msg_received:
-            self.get_logger().warn('Start configuration could not be checked! Check "joint_state" topic!')
+            self.get_logger().warn(
+                'Start configuration could not be checked! Check "joint_state" topic!'
+            )
         else:
-            self.get_logger().warn('Start configuration is not within configured limits!')
+            self.get_logger().warn("Start configuration is not within configured limits!")
 
     def joint_state_callback(self, msg):
 
         if not self.joint_state_msg_received:
 
             # check start state
-            limit_exceeded = [False]*len(msg.name)
+            limit_exceeded = [False] * len(msg.name)
             for idx, enum in enumerate(msg.name):
-                if (msg.position[idx] < self.starting_point[enum][0]) or\
-                        (msg.position[idx] > self.starting_point[enum][1]):
-                    self.get_logger().warn('Starting point limits exceeded for joint {} !'.format(enum))
+                if (msg.position[idx] < self.starting_point[enum][0]) or (
+                    msg.position[idx] > self.starting_point[enum][1]
+                ):
+                    self.get_logger().warn(f"Starting point limits exceeded for joint {enum} !")
                     limit_exceeded[idx] = True
 
             if any(limit_exceeded):

--- a/ros2_control_test_nodes/ros2_control_test_nodes/publisher_joint_trajectory_controller.py
+++ b/ros2_control_test_nodes/ros2_control_test_nodes/publisher_joint_trajectory_controller.py
@@ -47,7 +47,7 @@ class PublisherJointTrajectory(Node):
             # declare nested params
             for name in self.joints:
                 param_name_tmp = 'starting_point_limits' + '.' + name
-                self.declare_parameter(param_name_tmp)
+                self.declare_parameter(param_name_tmp, [-2*3.14159, 2*3.14159])
                 self.starting_point[name] = self.get_parameter(param_name_tmp).value
 
             for name in self.joints:

--- a/ros2_control_test_nodes/ros2_control_test_nodes/publisher_joint_trajectory_controller.py
+++ b/ros2_control_test_nodes/ros2_control_test_nodes/publisher_joint_trajectory_controller.py
@@ -17,6 +17,7 @@ from rclpy.node import Node
 from builtin_interfaces.msg import Duration
 
 from trajectory_msgs.msg import JointTrajectory, JointTrajectoryPoint
+from sensor_msgs.msg import JointState
 
 
 class PublisherJointTrajectory(Node):
@@ -27,15 +28,38 @@ class PublisherJointTrajectory(Node):
         self.declare_parameter("wait_sec_between_publish", 6)
         self.declare_parameter("goal_names", ["pos1", "pos2"])
         self.declare_parameter("joints")
+        self.declare_parameter('check_starting_point', False)
+        self.declare_parameter('starting_point_limits')
 
         # Read parameters
         controller_name = self.get_parameter("controller_name").value
         wait_sec_between_publish = self.get_parameter("wait_sec_between_publish").value
         goal_names = self.get_parameter("goal_names").value
         self.joints = self.get_parameter("joints").value
+        self.check_starting_point = self.get_parameter('check_starting_point').value
+        self.starting_point = {}
 
         if self.joints is None or len(self.joints) == 0:
             raise Exception('"joints" parameter is not set!')
+
+        # starting point stuff
+        if self.check_starting_point:
+            # declare nested params
+            for name in self.joints:
+                param_name_tmp = 'starting_point_limits' + '.' + name
+                self.declare_parameter(param_name_tmp)
+                self.starting_point[name] = self.get_parameter(param_name_tmp).value
+
+            for name in self.joints:
+                if len(self.starting_point[name]) != 2:
+                    raise Exception('"starting_point" parameter is not set correctly!')
+            self.joint_state_sub = self.create_subscription(
+                JointState,
+                'joint_states',
+                self.joint_state_callback,
+                10)
+        self.starting_point_ok = not self.check_starting_point
+        self.joint_state_msg_received = False
 
         # Read all positions from parameters
         self.goals = []
@@ -63,17 +87,46 @@ class PublisherJointTrajectory(Node):
         self.i = 0
 
     def timer_callback(self):
-        traj = JointTrajectory()
-        traj.joint_names = self.joints
-        point = JointTrajectoryPoint()
-        point.positions = self.goals[self.i]
-        point.time_from_start = Duration(sec=4)
 
-        traj.points.append(point)
-        self.publisher_.publish(traj)
+        if self.starting_point_ok:
 
-        self.i += 1
-        self.i %= len(self.goals)
+            traj = JointTrajectory()
+            traj.joint_names = self.joints
+            point = JointTrajectoryPoint()
+            point.positions = self.goals[self.i]
+            point.time_from_start = Duration(sec=4)
+
+            traj.points.append(point)
+            self.publisher_.publish(traj)
+
+            self.i += 1
+            self.i %= len(self.goals)
+
+        elif self.check_starting_point and not self.joint_state_msg_received:
+            self.get_logger().warn('Start configuration could not be checked! Check "joint_state" topic!')
+        else:
+            self.get_logger().warn('Start configuration is not within configured limits!')
+
+    def joint_state_callback(self, msg):
+
+        if not self.joint_state_msg_received:
+
+            # check start state
+            limit_exceeded = [False]*len(msg.name)
+            for idx, enum in enumerate(msg.name):
+                if (msg.position[idx] < self.starting_point[enum][0]) or\
+                        (msg.position[idx] > self.starting_point[enum][1]):
+                    self.get_logger().warn('Starting point limits exceeded for joint {} !'.format(enum))
+                    limit_exceeded[idx] = True
+
+            if any(limit_exceeded):
+                self.starting_point_ok = False
+            else:
+                self.starting_point_ok = True
+
+            self.joint_state_msg_received = True
+        else:
+            return
 
 
 def main(args=None):

--- a/ros2_control_test_nodes/ros2_control_test_nodes/publisher_joint_trajectory_controller.py
+++ b/ros2_control_test_nodes/ros2_control_test_nodes/publisher_joint_trajectory_controller.py
@@ -56,7 +56,12 @@ class PublisherJointTrajectory(Node):
             self.joint_state_sub = self.create_subscription(
                 JointState, "joint_states", self.joint_state_callback, 10
             )
-        self.starting_point_ok = not self.check_starting_point
+        # initialize starting point status
+        if not self.check_starting_point:
+            self.starting_point_ok = True
+        else:
+            self.starting_point_ok = False
+
         self.joint_state_msg_received = False
 
         # Read all positions from parameters


### PR DESCRIPTION
The PR aims to prepare joint_trajectory_publisher for checking the start conditions.

PR info:
- This is very useful when launching test nodes on the real hardware to protect the robot from collision.
- The start state check can be disabled by the configuration file
- Tackling [UR#94](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/issues/94)

Example of config file:

```
publisher_joint_trajectory_controller:

  ros__parameters:

    controller_name: "joint_trajectory_controller"
    wait_sec_between_publish: 6

    goal_names: ["pos1", "pos2", "pos3", "pos4"]
    pos1: [0.785, -1.57, 0.785, 0.785, 0.785, 0.785]
    pos2: [0.0, -1.57, 0.0, 0.0, 0.0, 0.0]
    pos3: [0.0, -1.57, 0.0, 0.0, -0.785, 0.0]
    pos4: [0.0, -1.57, 0.0, 0.0, 0.0, 0.0]

    joints:
      - shoulder_pan_joint
      - shoulder_lift_joint
      - elbow_joint
      - wrist_1_joint
      - wrist_2_joint
      - wrist_3_joint

    check_starting_point: true
    starting_point_limits:
        shoulder_pan_joint: [-0.1,0.1]
        shoulder_lift_joint: [-1.6,-1.5]
        elbow_joint: [-0.1,0.1]
        wrist_1_joint: [-0.1,0.1]
        wrist_2_joint: [-0.1,0.1]
        wrist_3_joint: [-0.1,0.1]
```