### PR TITLE
add control-toolbox as deb package to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ However, there might be cases in which not-yet released demos or features are on
 
 * Install dependencies (maybe you need `sudo`):
   ```
-  apt install ros-foxy-realtime-tools ros-foxy-xacro ros-foxy-angles
+  apt install ros-foxy-realtime-tools ros-foxy-xacro ros-foxy-angles ros-foxy-control-toolbox
   ```
 
 * Build everything, e.g. with:
@@ -452,7 +452,7 @@ Now you should also see the *RRbot* represented correctly in `RViz`.
 ## Result
 
 1. Independently from the controller you should see how the example's output changes.
-  Look for the following lines
+    Look for the following lines
    ```
    [RRBotSystemPositionOnlyHardware]: Got state 0.0 for joint 0!
    [RRBotSystemPositionOnlyHardware]: Got state 0.0 for joint 1!


### PR DESCRIPTION
since compilation fails without. control-toolbox installs also control_msgs which are needed from hardware_interface and are missing.