### PR TITLE
Fix python version in the format workflow

### DIFF
--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -17,8 +17,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
+      with:
+        python-version: 3.9.7
     - name: Install clang-format-10
       run: sudo apt-get install clang-format-10 cppcheck
-    - uses: pre-commit/action@v2.0.2
+    - uses: pre-commit/action@v2.0.3
       with:
         extra_args: --all-files --hook-stage manual


### PR DESCRIPTION
Had to do the same few days ago on other repositories, e.g., [UR-driver](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/commit/ee85a93395d7a67aca516169a69db9874adfa90a)

This is fixing python version because it seems that from python 3.10.x `pep257`'s dependencies were changed.

Also bumped a bug-fix version of the pre-commit action on the CI