### PR TITLE
remove invalid diff_drive_controller parameters

### DIFF
--- a/ros2_control_demo_bringup/config/diffbot_controllers.yaml
+++ b/ros2_control_demo_bringup/config/diffbot_controllers.yaml
@@ -35,15 +35,6 @@ diffbot_base_controller:
     use_stamped_vel: false
     #velocity_rolling_window_size: 10
 
-    # Preserve turning radius when limiting speed/acceleration/jerk
-    preserve_turning_radius: true
-
-    # Publish limited velocity
-    publish_cmd: true
-
-    # Publish wheel data
-    publish_wheel_data: true
-
     # Velocity and acceleration limits
     # Whenever a min_* is unspecified, default to -max_*
     linear.x.has_velocity_limits: true


### PR DESCRIPTION
* `publish_cmd` seems to be replaced with `publish_limited_velocity`
* `publish_wheel_data` seems to be not ported from ros1
* `preserve_turning_radius` seems to have never merged into ros1 and doesn't exist in ros2 either

Just ran into this as I was using it as reference for what parameters are available to play with. Is there some source of documentation to look for these things(like http://wiki.ros.org/diff_drive_controller#Parameters in ros1)?