### PR TITLE
Bugfix: Do not ignore prefix argument for joint names.

### DIFF
--- a/ros2_control_demo_description/rrbot_description/ros2_control/external_rrbot_force_torque_sensor.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/external_rrbot_force_torque_sensor.ros2_control.xacro
@@ -18,7 +18,7 @@
         </xacro:unless>
       </hardware>
 
-      <sensor name="tcp_fts_sensor">
+      <sensor name="${prefix}tcp_fts_sensor">
         <state_interface name="force.x"/>
         <state_interface name="force.y"/>
         <state_interface name="force.z"/>

--- a/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_modular_actuators.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_modular_actuators.ros2_control.xacro
@@ -10,7 +10,7 @@
         <param name="example_param_hw_stop_duration_sec">3.0</param>
         <param name="example_param_hw_slowdown">${slowdown}</param>
       </hardware>
-      <joint name="joint1">
+      <joint name="${prefix}joint1">
         <command_interface name="position">
           <param name="min">-100</param>
           <param name="max">100</param>
@@ -25,7 +25,7 @@
         <param name="example_param_hw_stop_duration_sec">3.0</param>
         <param name="example_param_hw_slowdown">${slowdown}</param>
       </hardware>
-      <joint name="joint2">
+      <joint name="${prefix}joint2">
         <command_interface name="position">
           <param name="min">-100</param>
           <param name="max">100</param>

--- a/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_multi_interface.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_multi_interface.ros2_control.xacro
@@ -26,7 +26,7 @@
         </hardware>
       </xacro:unless>
 
-      <joint name="joint1">
+      <joint name="${prefix}joint1">
         <command_interface name="position">
           <param name="min">-1</param>
           <param name="max">1</param>
@@ -43,7 +43,7 @@
         <state_interface name="velocity"/>
         <state_interface name="acceleration"/>
       </joint>
-      <joint name="joint2">
+      <joint name="${prefix}joint2">
         <command_interface name="position">
           <param name="min">-1</param>
           <param name="max">1</param>

--- a/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_position_only.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_position_only.ros2_control.xacro
@@ -26,14 +26,14 @@
         </hardware>
       </xacro:unless>
 
-      <joint name="joint1">
+      <joint name="${prefix}joint1">
         <command_interface name="position">
           <param name="min">-1</param>
           <param name="max">1</param>
         </command_interface>
         <state_interface name="position"/>
       </joint>
-      <joint name="joint2">
+      <joint name="${prefix}joint2">
         <command_interface name="position">
           <param name="min">-1</param>
           <param name="max">1</param>

--- a/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_with_sensor.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_with_sensor.ros2_control.xacro
@@ -20,21 +20,21 @@
         </xacro:unless>
       </hardware>
 
-      <joint name="joint1">
+      <joint name="${prefix}joint1">
         <command_interface name="position">
           <param name="min">-1</param>
           <param name="max">1</param>
         </command_interface>
         <state_interface name="position"/>
       </joint>
-      <joint name="joint2">
+      <joint name="${prefix}joint2">
         <command_interface name="position">
           <param name="min">-1</param>
           <param name="max">1</param>
         </command_interface>
         <state_interface name="position"/>
       </joint>
-      <sensor name="tcp_fts_sensor">
+      <sensor name="${prefix}tcp_fts_sensor">
         <state_interface name="force.x"/>
         <state_interface name="torque.z"/>
         <param name="frame_id">tool_link</param>


### PR DESCRIPTION
This PR fixes a bug where prefixes of joint names are ignored in URDF which causes problem when using prefix, e.g., when running multiple instances of hardware.﻿


P.S. CI is failing because it has to be updated after transition to jammy. So, I would like to proceed with this anyway.