### PR TITLE
Replace use_sim with use_gazebo

### DIFF
--- a/ros2_control_demo_bringup/launch/rrbot_base.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_base.launch.py
@@ -65,7 +65,7 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "use_sim",
+            "use_gazebo",
             default_value="false",
             description="Start robot in Gazebo simulation.",
         )
@@ -111,7 +111,7 @@ def generate_launch_description():
     description_package = LaunchConfiguration("description_package")
     description_file = LaunchConfiguration("description_file")
     prefix = LaunchConfiguration("prefix")
-    use_sim = LaunchConfiguration("use_sim")
+    use_gazebo = LaunchConfiguration("use_gazebo")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
     fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
     slowdown = LaunchConfiguration("slowdown")
@@ -130,8 +130,8 @@ def generate_launch_description():
             "prefix:=",
             prefix,
             " ",
-            "use_sim:=",
-            use_sim,
+            "use_gazebo:=",
+            use_gazebo,
             " ",
             "use_fake_hardware:=",
             use_fake_hardware,

--- a/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_position_only_gazebo.launch.py
@@ -41,7 +41,7 @@ def generate_launch_description():
                     "rrbot_system_position_only.urdf.xacro",
                 ]
             ),
-            " use_sim:=true",
+            " use_gazebo:=true",
         ]
     )
     robot_description = {"robot_description": robot_description_content}

--- a/ros2_control_demo_description/diffbot_description/urdf/diffbot_system.urdf.xacro
+++ b/ros2_control_demo_description/diffbot_description/urdf/diffbot_system.urdf.xacro
@@ -5,7 +5,7 @@ Copied and modified from ROS1 example -
 https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/diffbot_description/urdf/diffbot.xacro
 -->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="diffdrive_robot">
-  <xacro:arg name="use_sim" default="false" />
+  <xacro:arg name="use_gazebo" default="false" />
 
   <!-- Enable setting arguments from the launch file -->
   <xacro:arg name="use_fake_hardware" default="true" />

--- a/ros2_control_demo_description/rrbot_description/ros2_control/external_rrbot_force_torque_sensor.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/external_rrbot_force_torque_sensor.ros2_control.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="external_rrbot_force_torque_sensor" params="name prefix use_sim:=^|false use_fake_hardware:=^|true fake_sensor_commands:=^|false">
+  <xacro:macro name="external_rrbot_force_torque_sensor" params="name prefix use_gazebo:=^|false use_fake_hardware:=^|true fake_sensor_commands:=^|false">
 
     <ros2_control name="${name}" type="sensor">
       <hardware>

--- a/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_modular_actuators.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_modular_actuators.ros2_control.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="rrbot_modular_actuators" params="name prefix use_sim:=^|false slowdown:=2.0">
+  <xacro:macro name="rrbot_modular_actuators" params="name prefix use_gazebo:=^|false slowdown:=2.0">
 
     <ros2_control name="RRBotModularJoint1" type="actuator">
       <hardware>

--- a/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_multi_interface.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_multi_interface.ros2_control.xacro
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="rrbot_system_multi_interface" params="name prefix use_sim:=^|false use_fake_hardware:=^|true fake_sensor_commands:=^|false slowdown:=2.0">
+  <xacro:macro name="rrbot_system_multi_interface" params="name prefix use_gazebo:=^|false use_fake_hardware:=^|true fake_sensor_commands:=^|false slowdown:=2.0">
 
     <ros2_control name="${name}" type="system">
 
-      <xacro:if value="$(arg use_sim)">
+      <xacro:if value="$(arg use_gazebo)">
         <hardware>
           <plugin>gazebo_ros2_control/GazeboSystem</plugin>
         </hardware>
       </xacro:if>
-      <xacro:unless value="$(arg use_sim)">
+      <xacro:unless value="$(arg use_gazebo)">
         <hardware>
           <xacro:if value="${use_fake_hardware}">
             <plugin>fake_components/GenericSystem</plugin>

--- a/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_position_only.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_position_only.ros2_control.xacro
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="rrbot_system_position_only" params="name prefix use_sim:=^|false use_fake_hardware:=^|true fake_sensor_commands:=^|false slowdown:=2.0">
+  <xacro:macro name="rrbot_system_position_only" params="name prefix use_gazebo:=^|false use_fake_hardware:=^|true fake_sensor_commands:=^|false slowdown:=2.0">
 
     <ros2_control name="${name}" type="system">
 
-      <xacro:if value="$(arg use_sim)">
+      <xacro:if value="$(arg use_gazebo)">
         <hardware>
           <plugin>gazebo_ros2_control/GazeboSystem</plugin>
         </hardware>
       </xacro:if>
-      <xacro:unless value="$(arg use_sim)">
+      <xacro:unless value="$(arg use_gazebo)">
         <hardware>
           <xacro:if value="${use_fake_hardware}">
             <plugin>fake_components/GenericSystem</plugin>

--- a/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_with_sensor.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_with_sensor.ros2_control.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="rrbot_system_with_sensor" params="name prefix use_sim:=^|false use_fake_hardware:=^|true fake_sensor_commands:=^|false slowdown:=2.0">
+  <xacro:macro name="rrbot_system_with_sensor" params="name prefix use_gazebo:=^|false use_fake_hardware:=^|true fake_sensor_commands:=^|false slowdown:=2.0">
 
     <ros2_control name="${name}" type="system">
 

--- a/ros2_control_demo_description/rrbot_description/urdf/rrbot_modular_actuators.urdf.xacro
+++ b/ros2_control_demo_description/rrbot_description/urdf/rrbot_modular_actuators.urdf.xacro
@@ -5,7 +5,7 @@ Copied and modified from ROS1 example -
 https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_description/urdf/rrbot.xacro
 -->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="2dof_robot">
-  <xacro:arg name="use_sim" default="false" />
+  <xacro:arg name="use_gazebo" default="false" />
 
   <!-- Enable setting arguments from the launch file -->
   <xacro:arg name="prefix" default="" />

--- a/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_multi_interface.urdf.xacro
+++ b/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_multi_interface.urdf.xacro
@@ -5,7 +5,7 @@ Copied and modified from ROS1 example -
 https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_description/urdf/rrbot.xacro
 -->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="2dof_robot">
-  <xacro:arg name="use_sim" default="false" />
+  <xacro:arg name="use_gazebo" default="false" />
 
   <!-- Enable setting arguments from the launch file -->
   <xacro:arg name="use_fake_hardware" default="false" />

--- a/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_position_only.urdf.xacro
+++ b/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_position_only.urdf.xacro
@@ -5,7 +5,7 @@ Copied and modified from ROS1 example -
 https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_description/urdf/rrbot.xacro
 -->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="2dof_robot">
-  <xacro:arg name="use_sim" default="false" />
+  <xacro:arg name="use_gazebo" default="false" />
 
   <!-- Enable setting arguments from the launch file -->
   <xacro:arg name="use_fake_hardware" default="false" />

--- a/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_with_external_sensor.urdf.xacro
+++ b/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_with_external_sensor.urdf.xacro
@@ -5,7 +5,7 @@ Copied and modified from ROS1 example -
 https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_description/urdf/rrbot.xacro
 -->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="2dof_robot">
-  <xacro:arg name="use_sim" default="false" />
+  <xacro:arg name="use_gazebo" default="false" />
 
   <!-- Enable setting arguments from the launch file -->
   <xacro:arg name="use_fake_hardware" default="true" />

--- a/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_with_sensor.urdf.xacro
+++ b/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_with_sensor.urdf.xacro
@@ -5,7 +5,7 @@ Copied and modified from ROS1 example -
 https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_description/urdf/rrbot.xacro
 -->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="2dof_robot">
-  <xacro:arg name="use_sim" default="false" />
+  <xacro:arg name="use_gazebo" default="false" />
 
   <!-- Enable setting arguments from the launch file -->
   <xacro:arg name="use_fake_hardware" default="false" />


### PR DESCRIPTION
The `use_sim` arg was used to choose between Gazebo simulation or ros2_control `fake_components` simulation. Since they are both types of simulation, I propose renaming the arg to `use_gazebo`.