### PR TITLE
Fix warning about "output" from launch files

### DIFF
--- a/ros2_control_demo_bringup/launch/diffbot.launch.py
+++ b/ros2_control_demo_bringup/launch/diffbot.launch.py
@@ -49,10 +49,7 @@ def generate_launch_description():
         package="controller_manager",
         executable="ros2_control_node",
         parameters=[robot_description, robot_controllers],
-        output={
-            "stdout": "screen",
-            "stderr": "screen",
-        },
+        output="both",
     )
     robot_state_pub_node = Node(
         package="robot_state_publisher",

--- a/ros2_control_demo_bringup/launch/rrbot.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot.launch.py
@@ -60,10 +60,7 @@ def generate_launch_description():
                 "/position_commands",
             ),
         ],
-        output={
-            "stdout": "screen",
-            "stderr": "screen",
-        },
+        output="both",
     )
     robot_state_pub_node = Node(
         package="robot_state_publisher",

--- a/ros2_control_demo_bringup/launch/rrbot_base.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_base.launch.py
@@ -160,10 +160,7 @@ def generate_launch_description():
         package="controller_manager",
         executable="ros2_control_node",
         parameters=[robot_description, robot_controllers],
-        output={
-            "stdout": "screen",
-            "stderr": "screen",
-        },
+        output="both",
     )
     robot_state_pub_node = Node(
         package="robot_state_publisher",


### PR DESCRIPTION
Fix this warning due to a recent ROS2 Rolling update:

`[ERROR] [launch]: Caught exception in launch (see debug for traceback): stdoutstderr is not a valid standard output config i.e. "screen", "log" or "both"`