### PR TITLE
Rename position_trajectory_controller to joint_trajectory_controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,9 +496,9 @@ Now you should also see the *RRbot* represented correctly in `RViz`.
    joint_trajectory_position_controller[joint_trajectory_controller/JointTrajectoryController] active
    ```
 
-3. Send a command to the controller using demo node which sends two goals every 5 seconds in a loop:
+3. Send a command to the controller using demo node which sends two goals every 6 seconds in a loop:
    ```
-   ros2 launch ros2_control_demo_bringup test_forward_position_controller.launch.py
+   ros2 launch ros2_control_demo_bringup test_joint_trajectory_position_controller.launch.py
    ```
    You can adjust the goals in [rrbot_joint_trajectory_publisher.yaml](ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher.yaml).
 

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ Now you should also see the *RRbot* represented correctly in `RViz`.
 
 1. If you want to test hardware with `JointTrajectoryController` first load and configure a controller (not always needed):
    ```
-   ros2 control load_controller position_trajectory_controller --set-state configure
+   ros2 control load_controller joint_trajectory_controller --set-state configure
    ```
    Check if the controller is loaded and configured properly:
    ```
@@ -479,12 +479,12 @@ Now you should also see the *RRbot* represented correctly in `RViz`.
    ```
    You should get the response:
    ```
-   position_trajectory_controller[joint_trajectory_controller/JointTrajectoryController] inactive
+   joint_trajectory_controller[joint_trajectory_controller/JointTrajectoryController] inactive
    ```
 
 2. Now start the controller (and stop other running contorller):
    ```
-   ros2 control switch_controllers --stop forward_position_controller --start position_trajectory_controller
+   ros2 control switch_controllers --stop forward_position_controller --start joint_trajectory_controller
    ```
    Check if controllers are activated:
    ```
@@ -493,7 +493,7 @@ Now you should also see the *RRbot* represented correctly in `RViz`.
    You should get `active` in the response:
    ```
    joint_state_controller[joint_state_controller/JointStateController] active
-   position_trajectory_controller[joint_trajectory_controller/JointTrajectoryController] active
+   joint_trajectory_controller[joint_trajectory_controller/JointTrajectoryController] active
    ```
 
 3. Send a command to the controller using demo node which sends two goals every 5 seconds in a loop:

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ Now you should also see the *RRbot* represented correctly in `RViz`.
 
 1. If you want to test hardware with `JointTrajectoryController` first load and configure a controller (not always needed):
    ```
-   ros2 control load_controller joint_trajectory_controller --set-state configure
+   ros2 control load_controller joint_trajectory_position_controller --set-state configure
    ```
    Check if the controller is loaded and configured properly:
    ```
@@ -479,12 +479,12 @@ Now you should also see the *RRbot* represented correctly in `RViz`.
    ```
    You should get the response:
    ```
-   joint_trajectory_controller[joint_trajectory_controller/JointTrajectoryController] inactive
+   joint_trajectory_position_controller[joint_trajectory_controller/JointTrajectoryController] inactive
    ```
 
 2. Now start the controller (and stop other running contorller):
    ```
-   ros2 control switch_controllers --stop forward_position_controller --start joint_trajectory_controller
+   ros2 control switch_controllers --stop forward_position_controller --start joint_trajectory_position_controller
    ```
    Check if controllers are activated:
    ```
@@ -493,7 +493,7 @@ Now you should also see the *RRbot* represented correctly in `RViz`.
    You should get `active` in the response:
    ```
    joint_state_controller[joint_state_controller/JointStateController] active
-   joint_trajectory_controller[joint_trajectory_controller/JointTrajectoryController] active
+   joint_trajectory_position_controller[joint_trajectory_controller/JointTrajectoryController] active
    ```
 
 3. Send a command to the controller using demo node which sends two goals every 5 seconds in a loop:

--- a/ros2_control_demo_bringup/config/rrbot_controllers.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_controllers.yaml
@@ -8,7 +8,7 @@ controller_manager:
     forward_position_controller:
       type: forward_command_controller/ForwardCommandController
 
-    position_trajectory_controller:
+    joint_trajectory_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
 
@@ -20,7 +20,7 @@ forward_position_controller:
     interface_name: position
 
 
-position_trajectory_controller:
+joint_trajectory_controller:
   ros__parameters:
     joints:
       - joint1

--- a/ros2_control_demo_bringup/config/rrbot_controllers.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_controllers.yaml
@@ -8,7 +8,7 @@ controller_manager:
     forward_position_controller:
       type: forward_command_controller/ForwardCommandController
 
-    joint_trajectory_controller:
+    joint_trajectory_position_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
 
@@ -20,7 +20,7 @@ forward_position_controller:
     interface_name: position
 
 
-joint_trajectory_controller:
+joint_trajectory_position_controller:
   ros__parameters:
     joints:
       - joint1

--- a/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher.yaml
@@ -1,7 +1,7 @@
-publisher_joint_trajectory_controller:
+publisher_joint_trajectory_position_controller:
   ros__parameters:
 
-    controller_name: "joint_trajectory_controller"
+    controller_name: "joint_trajectory_position_controller"
     wait_sec_between_publish: 6
 
     goal_names: ["pos1", "pos2", "pos3", "pos4"]

--- a/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher.yaml
@@ -1,7 +1,7 @@
 publisher_joint_trajectory_controller:
   ros__parameters:
 
-    controller_name: "position_trajectory_controller"
+    controller_name: "joint_trajectory_controller"
     wait_sec_between_publish: 6
 
     goal_names: ["pos1", "pos2", "pos3", "pos4"]

--- a/ros2_control_demo_bringup/launch/rrbot.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot.launch.py
@@ -80,7 +80,7 @@ def generate_launch_description():
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner.py",
-        arguments=["joint_trajectory_controller", "--controller-manager", "/controller_manager"],
+        arguments=["forward_position_controller", "--controller-manager", "/controller_manager"],
     )
 
     nodes = [

--- a/ros2_control_demo_bringup/launch/rrbot.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot.launch.py
@@ -80,7 +80,7 @@ def generate_launch_description():
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner.py",
-        arguments=["forward_position_controller", "-c", "/controller_manager"],
+        arguments=["joint_trajectory_controller", "--controller-manager", "/controller_manager"],
     )
 
     nodes = [

--- a/ros2_control_demo_bringup/launch/rrbot_base.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_base.launch.py
@@ -188,7 +188,7 @@ def generate_launch_description():
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner.py",
-        arguments=[robot_controller, "-c", "/controller_manager"],
+        arguments=[robot_controller, "--controller-manager", "/controller_manager"],
     )
 
     nodes = [

--- a/ros2_control_demo_bringup/launch/test_joint_trajectory_position_controller.launch.py
+++ b/ros2_control_demo_bringup/launch/test_joint_trajectory_position_controller.launch.py
@@ -32,8 +32,8 @@ def generate_launch_description():
         [
             Node(
                 package="ros2_control_test_nodes",
-                executable="publisher_joint_trajectory_controller",
-                name="publisher_joint_trajectory_controller",
+                executable="publisher_joint_trajectory_position_controller",
+                name="publisher_joint_trajectory_position_controller",
                 parameters=[position_goals],
                 output={
                     "stdout": "screen",

--- a/ros2_control_test_nodes/ros2_control_test_nodes/publisher_joint_trajectory_controller.py
+++ b/ros2_control_test_nodes/ros2_control_test_nodes/publisher_joint_trajectory_controller.py
@@ -22,9 +22,9 @@ from sensor_msgs.msg import JointState
 
 class PublisherJointTrajectory(Node):
     def __init__(self):
-        super().__init__("publisher_position_trajectory_controller")
+        super().__init__("publisher_joint_trajectory_controller")
         # Declare all parameters
-        self.declare_parameter("controller_name", "position_trajectory_controller")
+        self.declare_parameter("controller_name", "joint_trajectory_controller")
         self.declare_parameter("wait_sec_between_publish", 6)
         self.declare_parameter("goal_names", ["pos1", "pos2"])
         self.declare_parameter("joints")

--- a/ros2_control_test_nodes/ros2_control_test_nodes/publisher_joint_trajectory_position_controller.py
+++ b/ros2_control_test_nodes/ros2_control_test_nodes/publisher_joint_trajectory_position_controller.py
@@ -22,9 +22,9 @@ from sensor_msgs.msg import JointState
 
 class PublisherJointTrajectory(Node):
     def __init__(self):
-        super().__init__("publisher_joint_trajectory_controller")
+        super().__init__("publisher_joint_trajectory_position_controller")
         # Declare all parameters
-        self.declare_parameter("controller_name", "joint_trajectory_controller")
+        self.declare_parameter("controller_name", "joint_trajectory_position_controller")
         self.declare_parameter("wait_sec_between_publish", 6)
         self.declare_parameter("goal_names", ["pos1", "pos2"])
         self.declare_parameter("joints")

--- a/ros2_control_test_nodes/setup.py
+++ b/ros2_control_test_nodes/setup.py
@@ -50,8 +50,8 @@ Demo nodes for showing and testing functionalities of the ros2_control framework
         "console_scripts": [
             "publisher_forward_position_controller = \
                 ros2_control_test_nodes.publisher_forward_position_controller:main",
-            "publisher_joint_trajectory_controller = \
-                ros2_control_test_nodes.publisher_joint_trajectory_controller:main",
+            "publisher_joint_trajectory_position_controller = \
+                ros2_control_test_nodes.publisher_joint_trajectory_position_controller:main",
         ],
     },
 )


### PR DESCRIPTION
Hello,

I am learning the ros2 control framework and found that there was a discrepancy in the naming consistency for the joint_trajectory_controller. To add clarity, I have renamed the controller to joint_trajectory_controller which fits well with the publisher and actual controller implementation names.

Additionally, I changed the spawner argument from -c to --controller-manager because these arguments were used interchangeably and was confusing for the learning. I guess the --controller-manager is more for a new learner..

Best,
Haider