### PR TITLE
fake_sensor_commands renamed

### DIFF
--- a/ros2_control_demo_bringup/launch/rrbot_base.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_base.launch.py
@@ -79,7 +79,7 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "fake_sensor_commands",
+            "mock_sensor_commands",
             default_value="false",
             description="Enable fake command interfaces for sensors used for simple simulations. \
             Used only if 'use_fake_hardware' parameter is true.",
@@ -113,7 +113,7 @@ def generate_launch_description():
     prefix = LaunchConfiguration("prefix")
     use_gazebo = LaunchConfiguration("use_gazebo")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
-    fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
+    mock_sensor_commands = LaunchConfiguration("mock_sensor_commands")
     slowdown = LaunchConfiguration("slowdown")
     robot_controller = LaunchConfiguration("robot_controller")
     start_rviz = LaunchConfiguration("start_rviz")
@@ -136,8 +136,8 @@ def generate_launch_description():
             "use_fake_hardware:=",
             use_fake_hardware,
             " ",
-            "fake_sensor_commands:=",
-            fake_sensor_commands,
+            "mock_sensor_commands:=",
+            mock_sensor_commands,
             " ",
             "slowdown:=",
             slowdown,

--- a/ros2_control_demo_bringup/launch/rrbot_system_multi_interface.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_multi_interface.launch.py
@@ -55,7 +55,7 @@ def generate_launch_description():
             "description_file": "rrbot_system_multi_interface.urdf.xacro",
             "prefix": prefix,
             "use_fake_hardware": "false",
-            "fake_sensor_commands": "false",
+            "mock_sensor_commands": "false",
             "slowdown": slowdown,
             "robot_controller": robot_controller,
         }.items(),

--- a/ros2_control_demo_bringup/launch/rrbot_system_position_only.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_position_only.launch.py
@@ -39,7 +39,7 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "fake_sensor_commands",
+            "mock_sensor_commands",
             default_value="false",
             description="Enable fake command interfaces for sensors used for simple simulations. \
             Used only if 'use_fake_hardware' parameter is true.",
@@ -68,7 +68,7 @@ def generate_launch_description():
     # Initialize Arguments
     prefix = LaunchConfiguration("prefix")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
-    fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
+    mock_sensor_commands = LaunchConfiguration("mock_sensor_commands")
     slowdown = LaunchConfiguration("slowdown")
     robot_controller = LaunchConfiguration("robot_controller")
     start_rviz = LaunchConfiguration("start_rviz")
@@ -79,7 +79,7 @@ def generate_launch_description():
             "description_file": "rrbot_system_position_only.urdf.xacro",
             "prefix": prefix,
             "use_fake_hardware": use_fake_hardware,
-            "fake_sensor_commands": fake_sensor_commands,
+            "mock_sensor_commands": mock_sensor_commands,
             "slowdown": slowdown,
             "robot_controller": robot_controller,
             "start_rviz": start_rviz,

--- a/ros2_control_demo_bringup/launch/rrbot_system_with_external_sensor.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_with_external_sensor.launch.py
@@ -42,7 +42,7 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "fake_sensor_commands",
+            "mock_sensor_commands",
             default_value="false",
             description="Enable fake command interfaces for sensors used for simple simulations. \
             Used only if 'use_fake_hardware' parameter is true.",
@@ -60,7 +60,7 @@ def generate_launch_description():
     # Initialize Arguments
     prefix = LaunchConfiguration("prefix")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
-    fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
+    mock_sensor_commands = LaunchConfiguration("mock_sensor_commands")
     slowdown = LaunchConfiguration("slowdown")
 
     base_launch = IncludeLaunchDescription(
@@ -70,7 +70,7 @@ def generate_launch_description():
             "description_file": "rrbot_system_with_external_sensor.urdf.xacro",
             "prefix": prefix,
             "use_fake_hardware": use_fake_hardware,
-            "fake_sensor_commands": fake_sensor_commands,
+            "mock_sensor_commands": mock_sensor_commands,
             "slowdown": slowdown,
         }.items(),
     )

--- a/ros2_control_demo_bringup/launch/rrbot_system_with_sensor.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_system_with_sensor.launch.py
@@ -42,7 +42,7 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "fake_sensor_commands",
+            "mock_sensor_commands",
             default_value="false",
             description="Enable fake command interfaces for sensors used for simple simulations. \
             Used only if 'use_fake_hardware' parameter is true.",
@@ -59,7 +59,7 @@ def generate_launch_description():
     # Initialize Arguments
     prefix = LaunchConfiguration("prefix")
     use_fake_hardware = LaunchConfiguration("use_fake_hardware")
-    fake_sensor_commands = LaunchConfiguration("fake_sensor_commands")
+    mock_sensor_commands = LaunchConfiguration("mock_sensor_commands")
     slowdown = LaunchConfiguration("slowdown")
 
     base_launch = IncludeLaunchDescription(
@@ -69,7 +69,7 @@ def generate_launch_description():
             "description_file": "rrbot_system_with_sensor.urdf.xacro",
             "prefix": prefix,
             "use_fake_hardware": use_fake_hardware,
-            "fake_sensor_commands": fake_sensor_commands,
+            "mock_sensor_commands": mock_sensor_commands,
             "slowdown": slowdown,
         }.items(),
     )

--- a/ros2_control_demo_description/diffbot_description/ros2_control/diffbot_system.ros2_control.xacro
+++ b/ros2_control_demo_description/diffbot_description/ros2_control/diffbot_system.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="diffbot_system" params="name prefix use_fake_hardware:=^|false fake_sensor_commands:=^|false">
+  <xacro:macro name="diffbot_system" params="name prefix use_fake_hardware:=^|false mock_sensor_commands:=^|false">
 
     <ros2_control name="${name}" type="system">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>mock_components/GenericSystem</plugin>
-          <param name="fake_sensor_commands">${fake_sensor_commands}</param>
+          <param name="mock_sensor_commands">${mock_sensor_commands}</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>
         <xacro:unless value="${use_fake_hardware}">

--- a/ros2_control_demo_description/diffbot_description/urdf/diffbot_system.urdf.xacro
+++ b/ros2_control_demo_description/diffbot_description/urdf/diffbot_system.urdf.xacro
@@ -9,7 +9,7 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/diffbot_de
 
   <!-- Enable setting arguments from the launch file -->
   <xacro:arg name="use_fake_hardware" default="true" />
-  <xacro:arg name="fake_sensor_commands" default="false" />
+  <xacro:arg name="mock_sensor_commands" default="false" />
   <xacro:arg name="prefix" default="" />
 
   <xacro:include filename="$(find diffbot_description)/urdf/diffbot.urdf.xacro" />
@@ -30,6 +30,6 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/diffbot_de
   <xacro:diffbot_system
     name="DiffBotSystem" prefix="$(arg prefix)"
     use_fake_hardware="$(arg use_fake_hardware)"
-    fake_sensor_commands="$(arg fake_sensor_commands)"/>
+    mock_sensor_commands="$(arg mock_sensor_commands)"/>
 
 </robot>

--- a/ros2_control_demo_description/rrbot_description/ros2_control/external_rrbot_force_torque_sensor.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/external_rrbot_force_torque_sensor.ros2_control.xacro
@@ -1,13 +1,13 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="external_rrbot_force_torque_sensor" params="name prefix use_gazebo:=^|false use_fake_hardware:=^|true fake_sensor_commands:=^|false">
+  <xacro:macro name="external_rrbot_force_torque_sensor" params="name prefix use_gazebo:=^|false use_fake_hardware:=^|true mock_sensor_commands:=^|false">
 
     <ros2_control name="${name}" type="sensor">
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>mock_components/GenericSystem</plugin>
-          <param name="fake_sensor_commands">${fake_sensor_commands}</param>
+          <param name="mock_sensor_commands">${mock_sensor_commands}</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>
         <xacro:unless value="${use_fake_hardware}">

--- a/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_multi_interface.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_multi_interface.ros2_control.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="rrbot_system_multi_interface" params="name prefix use_gazebo:=^|false use_fake_hardware:=^|true fake_sensor_commands:=^|false slowdown:=2.0">
+  <xacro:macro name="rrbot_system_multi_interface" params="name prefix use_gazebo:=^|false use_fake_hardware:=^|true mock_sensor_commands:=^|false slowdown:=2.0">
 
     <ros2_control name="${name}" type="system">
 
@@ -14,7 +14,7 @@
         <hardware>
           <xacro:if value="${use_fake_hardware}">
             <plugin>mock_components/GenericSystem</plugin>
-            <param name="fake_sensor_commands">${fake_sensor_commands}</param>
+            <param name="mock_sensor_commands">${mock_sensor_commands}</param>
             <param name="state_following_offset">0.0</param>
           </xacro:if>
           <xacro:unless value="${use_fake_hardware}">

--- a/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_position_only.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_position_only.ros2_control.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="rrbot_system_position_only" params="name prefix use_gazebo:=^|false use_fake_hardware:=^|true fake_sensor_commands:=^|false slowdown:=2.0">
+  <xacro:macro name="rrbot_system_position_only" params="name prefix use_gazebo:=^|false use_fake_hardware:=^|true mock_sensor_commands:=^|false slowdown:=2.0">
 
     <ros2_control name="${name}" type="system">
 
@@ -14,7 +14,7 @@
         <hardware>
           <xacro:if value="${use_fake_hardware}">
             <plugin>mock_components/GenericSystem</plugin>
-            <param name="fake_sensor_commands">${fake_sensor_commands}</param>
+            <param name="mock_sensor_commands">${mock_sensor_commands}</param>
             <param name="state_following_offset">0.0</param>
           </xacro:if>
           <xacro:unless value="${use_fake_hardware}">

--- a/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_with_sensor.ros2_control.xacro
+++ b/ros2_control_demo_description/rrbot_description/ros2_control/rrbot_system_with_sensor.ros2_control.xacro
@@ -1,14 +1,14 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="rrbot_system_with_sensor" params="name prefix use_gazebo:=^|false use_fake_hardware:=^|true fake_sensor_commands:=^|false slowdown:=2.0">
+  <xacro:macro name="rrbot_system_with_sensor" params="name prefix use_gazebo:=^|false use_fake_hardware:=^|true mock_sensor_commands:=^|false slowdown:=2.0">
 
     <ros2_control name="${name}" type="system">
 
       <hardware>
         <xacro:if value="${use_fake_hardware}">
           <plugin>mock_components/GenericSystem</plugin>
-          <param name="fake_sensor_commands">${fake_sensor_commands}</param>
+          <param name="mock_sensor_commands">${mock_sensor_commands}</param>
           <param name="state_following_offset">0.0</param>
         </xacro:if>
         <xacro:unless value="${use_fake_hardware}">

--- a/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_multi_interface.urdf.xacro
+++ b/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_multi_interface.urdf.xacro
@@ -9,7 +9,7 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_desc
 
   <!-- Enable setting arguments from the launch file -->
   <xacro:arg name="use_fake_hardware" default="false" />
-  <xacro:arg name="fake_sensor_commands" default="false" />
+  <xacro:arg name="mock_sensor_commands" default="false" />
   <xacro:arg name="prefix" default="" />
   <xacro:arg name="slowdown" default="100.0" />
 
@@ -40,7 +40,7 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_desc
   <xacro:rrbot_system_multi_interface
     name="RRBotSystemMultiInterface" prefix="$(arg prefix)"
     use_fake_hardware="$(arg use_fake_hardware)"
-    fake_sensor_commands="$(arg fake_sensor_commands)"
+    mock_sensor_commands="$(arg mock_sensor_commands)"
     slowdown="$(arg slowdown)" />
 
 </robot>

--- a/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_position_only.urdf.xacro
+++ b/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_position_only.urdf.xacro
@@ -9,7 +9,7 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_desc
 
   <!-- Enable setting arguments from the launch file -->
   <xacro:arg name="use_fake_hardware" default="false" />
-  <xacro:arg name="fake_sensor_commands" default="false" />
+  <xacro:arg name="mock_sensor_commands" default="false" />
   <xacro:arg name="prefix" default="" />
   <xacro:arg name="slowdown" default="100.0" />
 
@@ -40,7 +40,7 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_desc
   <xacro:rrbot_system_position_only
     name="RRBotSystemPositionOnly" prefix="$(arg prefix)"
     use_fake_hardware="$(arg use_fake_hardware)"
-    fake_sensor_commands="$(arg fake_sensor_commands)"
+    mock_sensor_commands="$(arg mock_sensor_commands)"
     slowdown="$(arg slowdown)" />
 
 </robot>

--- a/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_with_external_sensor.urdf.xacro
+++ b/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_with_external_sensor.urdf.xacro
@@ -9,7 +9,7 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_desc
 
   <!-- Enable setting arguments from the launch file -->
   <xacro:arg name="use_fake_hardware" default="true" />
-  <xacro:arg name="fake_sensor_commands" default="false" />
+  <xacro:arg name="mock_sensor_commands" default="false" />
   <xacro:arg name="prefix" default="" />
   <xacro:arg name="slowdown" default="50.0" />
 
@@ -38,11 +38,11 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_desc
   <xacro:rrbot_system_position_only
     name="RRBotSystemPositionOnly" prefix="$(arg prefix)"
     use_fake_hardware="$(arg use_fake_hardware)"
-    fake_sensor_commands="$(arg fake_sensor_commands)"
+    mock_sensor_commands="$(arg mock_sensor_commands)"
     slowdown="$(arg slowdown)" />
 
   <xacro:external_rrbot_force_torque_sensor
     name="ExternalRRBotFTSensor" prefix="$(arg prefix)"
     use_fake_hardware="$(arg use_fake_hardware)"
-    fake_sensor_commands="$(arg fake_sensor_commands)" />
+    mock_sensor_commands="$(arg mock_sensor_commands)" />
 </robot>

--- a/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_with_sensor.urdf.xacro
+++ b/ros2_control_demo_description/rrbot_description/urdf/rrbot_system_with_sensor.urdf.xacro
@@ -9,7 +9,7 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_desc
 
   <!-- Enable setting arguments from the launch file -->
   <xacro:arg name="use_fake_hardware" default="false" />
-  <xacro:arg name="fake_sensor_commands" default="false" />
+  <xacro:arg name="mock_sensor_commands" default="false" />
   <xacro:arg name="prefix" default="" />
   <xacro:arg name="slowdown" default="50.0" />
 
@@ -35,7 +35,7 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_desc
   <xacro:rrbot_system_with_sensor
     name="RRBotSystemWithSensor" prefix="$(arg prefix)"
     use_fake_hardware="$(arg use_fake_hardware)"
-    fake_sensor_commands="$(arg fake_sensor_commands)"
+    mock_sensor_commands="$(arg mock_sensor_commands)"
     slowdown="$(arg slowdown)" />
 
 </robot>


### PR DESCRIPTION
This PR resolves #193 issue to refactor all of `fake_sensor_commands` to `mock_sensor_commands`. The dependent issue https://github.com/ros-controls/ros2_control/issues/774 is resolved by the PR https://github.com/ros-controls/ros2_control/pull/782