### PR TITLE
Added examples to start jtc with Ruckig interpolation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,15 @@ Now you should also see the *RRbot* represented correctly in `RViz`.
 
 Checkout `chainable-jtc-with-ruckig-smoothing` from https://github.com/destogl/ros2_controllers.git
 
+To test the output consider the following data:
+
+- Splines output: topic `~/splines_output` field `actual`
+- Ruckig input curent state: topic `~/ruckig_input_current` field `actual`
+- Ruckig input target state: topic `~/ruckig_input_target` field `actual`
+- Ruckig output (controllers output): topic `~/state` field `desired`
+
+**TIPP**: Ploting positions independantly from velocities and accelerations is very helpful :D
+
 ### One DoF & position only commands
 
 1. First terminal:

--- a/README.md
+++ b/README.md
@@ -665,3 +665,54 @@ Now you should also see the *RRbot* represented correctly in `RViz`.
    ```
 
 3. You should also see the *RRbot* moving in `RViz`.
+
+
+# Testing JTC with Ruckig
+
+Checkout `chainable-jtc-with-ruckig-smoothing` from https://github.com/destogl/ros2_controllers.git
+
+### One DoF & position only commands
+
+1. First terminal:
+   ```
+   ros2 launch ros2_control_demo_bringup rrbot_jtc_ruckig_one_dof_test.launch.py
+   ```
+
+2. Second terminal - launch publisher within limits:
+   ```
+   ros2 launch ros2_control_demo_bringup test_rrbot_jtc_position_only_ruckig_one_dof_within_limits.launch.py
+   ```
+
+3. or start publisher with goals outside of limits:
+   ```
+   ros2 launch ros2_control_demo_bringup test_rrbot_jtc_position_only_ruckig_one_dof_outside_limits.launch.py
+   ```
+
+### One DoF & velocity only commands
+
+1. First terminal:
+   ```
+   ros2 launch ros2_control_demo_bringup rrbot_jtc_ruckig_one_dof_test.launch.py
+   ```
+
+2. Second terminal:
+   ```
+   ros2 launch ros2_control_demo_bringup test_rrbot_jtc_velocity_only_ruckig_one_dof_within_limits.launch.py
+   ```
+
+3. or start publisher with goals outside of limits:
+   ```
+   ros2 launch ros2_control_demo_bringup test_rrbot_jtc_velocity_only_ruckig_one_dof_outside_limits.launch.py
+   ```
+
+### Two DoFs & velocity only commands
+
+1. First terminal:
+   ```
+   ros2 launch ros2_control_demo_bringup rrbot_jtc_ruckig_two_dofs_test.launch.py
+   ```
+
+2. Second terminal:
+   ```
+   ros2 launch ros2_control_demo_bringup test_rrbot_jtc_velocity_only_ruckig_two_dofs_within_limits.launch.py
+   ```

--- a/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher_position_only_ruckig_outside_limits.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher_position_only_ruckig_outside_limits.yaml
@@ -1,0 +1,20 @@
+publisher_joint_trajectory_controller:
+  ros__parameters:
+
+    controller_name: "joint_trajectory_controller_ruckig_smoothing"
+    wait_sec_between_publish: 6.0
+    repeat_the_same_goal: 1  # useful to simulate continuous inputs
+
+    goal_time_from_start: 3.0
+    goal_names: ["pos1", "pos2", "pos3", "pos4"]
+    pos1:
+      positions: [100.0]
+    pos2:
+      positions: [0.0]
+    pos3:
+      positions: [-100.0]
+    pos4:
+      positions: [0.0]
+
+    joints:
+      - joint1

--- a/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher_position_only_ruckig_within_limits.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher_position_only_ruckig_within_limits.yaml
@@ -1,0 +1,20 @@
+publisher_joint_trajectory_controller:
+  ros__parameters:
+
+    controller_name: "joint_trajectory_controller_ruckig_smoothing"
+    wait_sec_between_publish: 6.0
+    repeat_the_same_goal: 1  # useful to simulate continuous inputs
+
+    goal_time_from_start: 3.0
+    goal_names: ["pos1", "pos2", "pos3", "pos4"]
+    pos1:
+      positions: [1.0]
+    pos2:
+      positions: [0.0]
+    pos3:
+      positions: [-1.0]
+    pos4:
+      positions: [0.0]
+
+    joints:
+      - joint1

--- a/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher_velocity_only_ruckig_outside_limits.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher_velocity_only_ruckig_outside_limits.yaml
@@ -1,0 +1,20 @@
+publisher_joint_trajectory_controller:
+  ros__parameters:
+
+    controller_name: "joint_trajectory_controller_ruckig_smoothing"
+    wait_sec_between_publish: 6.0
+    repeat_the_same_goal: 1  # useful to simulate continuous inputs
+
+    goal_time_from_start: 3.0
+    goal_names: ["pos1", "pos2", "pos3", "pos4"]
+    pos1:
+      velocities: [9.0]
+    pos2:
+      velocities: [0.0]
+    pos3:
+      velocities: [-9.0]
+    pos4:
+      velocities: [0.0]
+
+    joints:
+      - joint1

--- a/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher_velocity_only_ruckig_within_limits.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher_velocity_only_ruckig_within_limits.yaml
@@ -1,0 +1,20 @@
+publisher_joint_trajectory_controller:
+  ros__parameters:
+
+    controller_name: "joint_trajectory_controller_ruckig_smoothing"
+    wait_sec_between_publish: 6.0
+    repeat_the_same_goal: 1  # useful to simulate continuous inputs
+
+    goal_time_from_start: 3.0
+    goal_names: ["pos1", "pos2", "pos3", "pos4"]
+    pos1:
+      velocities: [4.0]
+    pos2:
+      velocities: [0.0]
+    pos3:
+      velocities: [-4.0]
+    pos4:
+      velocities: [0.0]
+
+    joints:
+      - joint1

--- a/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher_velocity_only_ruckig_within_limits_2_dofs.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_joint_trajectory_publisher_velocity_only_ruckig_within_limits_2_dofs.yaml
@@ -1,0 +1,21 @@
+publisher_joint_trajectory_controller:
+  ros__parameters:
+
+    controller_name: "joint_trajectory_controller_ruckig_smoothing"
+    wait_sec_between_publish: 6.0
+    repeat_the_same_goal: 1  # useful to simulate continuous inputs
+
+    goal_time_from_start: 3.0
+    goal_names: ["pos1", "pos2", "pos3", "pos4"]
+    pos1:
+      velocities: [0.2, 0.2]
+    pos2:
+      velocities: [0.0, 0.0]
+    pos3:
+      velocities: [-0.2, -0.2]
+    pos4:
+      velocities:  [0.0, 0.0]
+
+    joints:
+      - joint1
+      - joint2

--- a/ros2_control_demo_bringup/config/rrbot_jtc_ruckig_one_dof_test.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_jtc_ruckig_one_dof_test.yaml
@@ -1,0 +1,45 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 100  # Hz
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    joint_trajectory_controller_ruckig_smoothing:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+
+joint_trajectory_controller_ruckig_smoothing:
+  ros__parameters:
+    joints:
+      - joint1
+
+    command_interfaces:
+      - position
+      - velocity
+
+    state_interfaces:
+      - position
+      - velocity
+
+    state_publish_rate: 200.0 # Defaults to 50
+    action_monitor_rate: 20.0 # Defaults to 20
+
+    interpolation_method: ruckig
+
+    allow_partial_joints_goal: false # Defaults to false
+    open_loop_control: true
+    allow_integration_in_goal_trajectories: true
+    constraints:
+      stopped_velocity_tolerance: 0.01 # Defaults to 0.01
+      goal_time: 0.0 # Defaults to 0.0 (start immediately)
+
+    joint_limits:
+      joint1:
+        has_position_limits: false
+        has_velocity_limits: true
+        max_velocity: 8.0
+        has_acceleration_limits: true
+        max_acceleration: 2.0
+        has_jerk_limits: true
+        max_jerk: 1000.0

--- a/ros2_control_demo_bringup/config/rrbot_jtc_ruckig_two_dofs_test.yaml
+++ b/ros2_control_demo_bringup/config/rrbot_jtc_ruckig_two_dofs_test.yaml
@@ -1,0 +1,54 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 100  # Hz
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    joint_trajectory_controller_ruckig_smoothing:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+
+joint_trajectory_controller_ruckig_smoothing:
+  ros__parameters:
+    joints:
+      - joint1
+      - joint2
+
+    command_interfaces:
+      - position
+      - velocity
+
+    state_interfaces:
+      - position
+      - velocity
+
+    state_publish_rate: 200.0 # Defaults to 50
+    action_monitor_rate: 20.0 # Defaults to 20
+
+    interpolation_method: ruckig
+
+    allow_partial_joints_goal: false # Defaults to false
+    open_loop_control: true
+    allow_integration_in_goal_trajectories: true
+    constraints:
+      stopped_velocity_tolerance: 0.01 # Defaults to 0.01
+      goal_time: 0.0 # Defaults to 0.0 (start immediately)
+
+    joint_limits:
+      joint1:
+        has_position_limits: false
+        has_velocity_limits: true
+        max_velocity: 8.0
+        has_acceleration_limits: true
+        max_acceleration: 2.0
+        has_jerk_limits: true
+        max_jerk: 1000.0
+      joint2:
+        has_position_limits: false
+        has_velocity_limits: true
+        max_velocity: 6.0
+        has_acceleration_limits: true
+        max_acceleration: 1.0
+        has_jerk_limits: true
+        max_jerk: 1000.0

--- a/ros2_control_demo_bringup/launch/rrbot_jtc_ruckig_one_dof_test.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_jtc_ruckig_one_dof_test.launch.py
@@ -1,0 +1,38 @@
+# Copyright 2021 Department of Engineering Cybernetics, NTNU.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, ThisLaunchFileDir
+
+
+def generate_launch_description():
+    # Declare arguments
+    declared_arguments = []
+
+    base_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([ThisLaunchFileDir(), "/rrbot_base.launch.py"]),
+        launch_arguments={
+            "controllers_file": "rrbot_jtc_ruckig_one_dof_test.yaml",
+            "description_file": "rrbot_system_multi_interface.urdf.xacro",
+            "prefix": "",
+            "use_fake_hardware": "true",
+            "fake_sensor_commands": "false",
+            "slowdown": "1.0",
+            "robot_controller": "joint_trajectory_controller_ruckig_smoothing",
+        }.items(),
+    )
+
+    return LaunchDescription(declared_arguments + [base_launch])

--- a/ros2_control_demo_bringup/launch/rrbot_jtc_ruckig_two_dofs_test.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot_jtc_ruckig_two_dofs_test.launch.py
@@ -1,0 +1,38 @@
+# Copyright 2021 Department of Engineering Cybernetics, NTNU.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, ThisLaunchFileDir
+
+
+def generate_launch_description():
+    # Declare arguments
+    declared_arguments = []
+
+    base_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([ThisLaunchFileDir(), "/rrbot_base.launch.py"]),
+        launch_arguments={
+            "controllers_file": "rrbot_jtc_ruckig_two_dofs_test.yaml",
+            "description_file": "rrbot_system_multi_interface.urdf.xacro",
+            "prefix": "",
+            "use_fake_hardware": "true",
+            "fake_sensor_commands": "false",
+            "slowdown": "1.0",
+            "robot_controller": "joint_trajectory_controller_ruckig_smoothing",
+        }.items(),
+    )
+
+    return LaunchDescription(declared_arguments + [base_launch])

--- a/ros2_control_demo_bringup/launch/test_rrbot_jtc_position_only_ruckig_one_dof_outside_limits.launch.py
+++ b/ros2_control_demo_bringup/launch/test_rrbot_jtc_position_only_ruckig_one_dof_outside_limits.launch.py
@@ -1,0 +1,41 @@
+# Copyright 2021 Stogl Robotics Consulting UG (haftungsbeschränkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    position_goals = PathJoinSubstitution(
+        [
+            FindPackageShare("ros2_control_demo_bringup"),
+            "config",
+            "rrbot_joint_trajectory_publisher_position_only_ruckig_outside_limits.yaml",
+        ]
+    )
+
+    return LaunchDescription(
+        [
+            Node(
+                package="ros2_controllers_test_nodes",
+                executable="publisher_joint_trajectory_controller",
+                name="publisher_joint_trajectory_controller",
+                parameters=[position_goals],
+                output="both",
+            )
+        ]
+    )

--- a/ros2_control_demo_bringup/launch/test_rrbot_jtc_position_only_ruckig_one_dof_within_limits.launch.py
+++ b/ros2_control_demo_bringup/launch/test_rrbot_jtc_position_only_ruckig_one_dof_within_limits.launch.py
@@ -1,0 +1,41 @@
+# Copyright 2021 Stogl Robotics Consulting UG (haftungsbeschränkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    position_goals = PathJoinSubstitution(
+        [
+            FindPackageShare("ros2_control_demo_bringup"),
+            "config",
+            "rrbot_joint_trajectory_publisher_position_only_ruckig_within_limits.yaml",
+        ]
+    )
+
+    return LaunchDescription(
+        [
+            Node(
+                package="ros2_controllers_test_nodes",
+                executable="publisher_joint_trajectory_controller",
+                name="publisher_joint_trajectory_controller",
+                parameters=[position_goals],
+                output="both",
+            )
+        ]
+    )

--- a/ros2_control_demo_bringup/launch/test_rrbot_jtc_velocity_only_ruckig_one_dof_outside_limits.launch.py
+++ b/ros2_control_demo_bringup/launch/test_rrbot_jtc_velocity_only_ruckig_one_dof_outside_limits.launch.py
@@ -1,0 +1,41 @@
+# Copyright 2021 Stogl Robotics Consulting UG (haftungsbeschränkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    position_goals = PathJoinSubstitution(
+        [
+            FindPackageShare("ros2_control_demo_bringup"),
+            "config",
+            "rrbot_joint_trajectory_publisher_velocity_only_ruckig_outside_limits.yaml",
+        ]
+    )
+
+    return LaunchDescription(
+        [
+            Node(
+                package="ros2_controllers_test_nodes",
+                executable="publisher_joint_trajectory_controller",
+                name="publisher_joint_trajectory_controller",
+                parameters=[position_goals],
+                output="both",
+            )
+        ]
+    )

--- a/ros2_control_demo_bringup/launch/test_rrbot_jtc_velocity_only_ruckig_one_dof_within_limits.launch.py
+++ b/ros2_control_demo_bringup/launch/test_rrbot_jtc_velocity_only_ruckig_one_dof_within_limits.launch.py
@@ -1,0 +1,41 @@
+# Copyright 2021 Stogl Robotics Consulting UG (haftungsbeschränkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    position_goals = PathJoinSubstitution(
+        [
+            FindPackageShare("ros2_control_demo_bringup"),
+            "config",
+            "rrbot_joint_trajectory_publisher_velocity_only_ruckig_within_limits.yaml",
+        ]
+    )
+
+    return LaunchDescription(
+        [
+            Node(
+                package="ros2_controllers_test_nodes",
+                executable="publisher_joint_trajectory_controller",
+                name="publisher_joint_trajectory_controller",
+                parameters=[position_goals],
+                output="both",
+            )
+        ]
+    )

--- a/ros2_control_demo_bringup/launch/test_rrbot_jtc_velocity_only_ruckig_two_dofs_within_limits.launch.py
+++ b/ros2_control_demo_bringup/launch/test_rrbot_jtc_velocity_only_ruckig_two_dofs_within_limits.launch.py
@@ -1,0 +1,41 @@
+# Copyright 2021 Stogl Robotics Consulting UG (haftungsbeschränkt)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from launch import LaunchDescription
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+
+    position_goals = PathJoinSubstitution(
+        [
+            FindPackageShare("ros2_control_demo_bringup"),
+            "config",
+            "rrbot_joint_trajectory_publisher_velocity_only_ruckig_within_limits_2_dofs.yaml",
+        ]
+    )
+
+    return LaunchDescription(
+        [
+            Node(
+                package="ros2_controllers_test_nodes",
+                executable="publisher_joint_trajectory_controller",
+                name="publisher_joint_trajectory_controller",
+                parameters=[position_goals],
+                output="both",
+            )
+        ]
+    )


### PR DESCRIPTION
Check README changes for information on starting the examples.