### PR TITLE
🔧 Fixes and updated on pre-commit hooks and their action.

### DIFF
--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4.4.0
       with:
-        python-version: 3.9.7
+        python-version: '3.10'
     - name: Install system hooks
-      run: sudo apt install -qq clang-format-11 cppcheck
-    - uses: pre-commit/action@v2.0.3
+      run: sudo apt install -qq clang-format-14 cppcheck
+    - uses: pre-commit/action@v3.0.0
       with:
         extra_args: --all-files --hook-stage manual

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@
 repos:
   # Standard hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -33,26 +33,26 @@ repos:
 
   # Python hooks
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.1
+    rev: v3.3.1
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
 
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.12.0
     hooks:
       - id: black
         args: ["--line-length=99"]
 
-  # PEP 257
-  - repo: https://github.com/FalconSocial/pre-commit-mirrors-pep257
-    rev: v0.3.3
+  # PyDocStyle
+  - repo: https://github.com/PyCQA/pydocstyle
+    rev: 6.2.3
     hooks:
-    - id: pep257
+    - id: pydocstyle
       args: ["--ignore=D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404"]
 
   - repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
     - id: flake8
       args: ["--ignore=E501"]
@@ -63,7 +63,7 @@ repos:
       - id: clang-format
         name: clang-format
         description: Format files with ClangFormat.
-        entry: clang-format-10
+        entry: clang-format-14
         language: system
         files: \.(c|cc|cxx|cpp|frag|glsl|h|hpp|hxx|ih|ispc|ipp|java|js|m|proto|vert)$
         args: ['-fallback-style=none', '-i']
@@ -119,7 +119,7 @@ repos:
 
   # Docs - RestructuredText hooks
   - repo: https://github.com/PyCQA/doc8
-    rev: 0.10.1
+    rev: v1.1.1
     hooks:
       - id: doc8
         args: ['--max-line-length=100', '--ignore=D001']
@@ -136,7 +136,7 @@ repos:
   # Spellcheck in comments and docs
   # skipping of *.svg files is not working...
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.2
     hooks:
       - id: codespell
         args: ['--write-changes']

--- a/ros2_control_demo_hardware/src/rrbot_system_multi_interface.cpp
+++ b/ros2_control_demo_hardware/src/rrbot_system_multi_interface.cpp
@@ -164,9 +164,9 @@ hardware_interface::return_type RRBotSystemMultiInterfaceHardware::prepare_comma
     return hardware_interface::return_type::ERROR;
   }
   // Example criteria: All joints must have the same command mode
-  if (!std::all_of(new_modes.begin() + 1, new_modes.end(), [&](integration_level_t mode) {
-        return mode == new_modes[0];
-      }))
+  if (!std::all_of(
+        new_modes.begin() + 1, new_modes.end(),
+        [&](integration_level_t mode) { return mode == new_modes[0]; }))
   {
     return hardware_interface::return_type::ERROR;
   }

--- a/ros2_control_test_nodes/ros2_control_test_nodes/publisher_forward_position_controller.py
+++ b/ros2_control_test_nodes/ros2_control_test_nodes/publisher_forward_position_controller.py
@@ -27,7 +27,7 @@ class PublisherForwardPosition(Node):
         self.declare_parameter("goal_names", ["pos1", "pos2"])
 
         # Read parameters
-        controller_name = self.get_parameter("controller_name").value
+        # controller_name = self.get_parameter("controller_name").value
         wait_sec_between_publish = self.get_parameter("wait_sec_between_publish").value
         goal_names = self.get_parameter("goal_names").value
 


### PR DESCRIPTION
- Use pydocstyle instead of pep257 because it replaces it.
- Bump versions of hooks.
- Remove fixed python version from formatting action.
- Fix action warnings about Node.js 12 by updating them.
- Bump version of clang-format.
- correct formatting.
