### PR TITLE
Use /forward_position_controller/commands for all demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The *RRBot* URDF files can be found in the `urdf` folder of `rrbot_description` 
 
    a. Manually using ros2 cli interface:
    ```
-   ros2 topic pub /position_commands std_msgs/msg/Float64MultiArray "data:
+   ros2 topic pub /forward_position_controller/commands std_msgs/msg/Float64MultiArray "data:
    - 0.5
    - 0.5"
    ```
@@ -629,7 +629,7 @@ Now you should also see the *RRbot* represented correctly in `RViz`.
    position_trajectory_controller[joint_trajectory_controller/JointTrajectoryController] inactive
    ```
 
-2. Now start the controller (and stop other running contorller):
+2. Now start the controller (and stop other running controller):
    ```
    ros2 control switch_controllers --stop forward_position_controller --start position_trajectory_controller
    ```

--- a/ros2_control_demo_bringup/launch/rrbot.launch.py
+++ b/ros2_control_demo_bringup/launch/rrbot.launch.py
@@ -54,12 +54,6 @@ def generate_launch_description():
         package="controller_manager",
         executable="ros2_control_node",
         parameters=[robot_description, robot_controllers],
-        remappings=[
-            (
-                "/forward_position_controller/commands",
-                "/position_commands",
-            ),
-        ],
         output="both",
     )
     robot_state_pub_node = Node(

--- a/ros2_control_test_nodes/ros2_control_test_nodes/publisher_forward_position_controller.py
+++ b/ros2_control_test_nodes/ros2_control_test_nodes/publisher_forward_position_controller.py
@@ -44,7 +44,7 @@ class PublisherForwardPosition(Node):
                 float_goal.append(float(value))
             self.goals.append(float_goal)
 
-        publish_topic = "/position_commands"
+        publish_topic = "/forward_position_controller/commands"
 
         self.get_logger().info(
             f'Publishing {len(goal_names)} goals on topic "{publish_topic}"\


### PR DESCRIPTION
Some of the demos did not work with forward_position_controller due to mismatch of the command topic name. 

I removed the remapping in one launch file and changed the remains to have consistent `/forward_position_controller/commands` commands for all demos.