### PR TITLE
[Example 8] split hw interfaces -> state & command interfaces

### DIFF
--- a/example_8/hardware/rrbot_transmissions_system_position_only.cpp
+++ b/example_8/hardware/rrbot_transmissions_system_position_only.cpp
@@ -95,8 +95,10 @@ hardware_interface::CallbackReturn RRBotTransmissionsSystemPositionOnlyHardware:
     for (const auto & joint_info : transmission_info.joints)
     {
       // this demo supports only one interface per joint
-      if (!(joint_info.interfaces.size() == 1 &&
-            joint_info.interfaces[0] == hardware_interface::HW_IF_POSITION))
+      if (!(joint_info.state_interfaces.size() == 1 &&
+            joint_info.state_interfaces[0] == hardware_interface::HW_IF_POSITION &&
+            joint_info.command_interfaces.size() == 1 &&
+            joint_info.command_interfaces[0] == hardware_interface::HW_IF_POSITION))
       {
         RCLCPP_FATAL(
           *logger_, "Invalid transmission joint '%s' configuration for this demo",


### PR DESCRIPTION
Adjusted to ros2_control commit to split interfaces: https://github.com/ros-controls/ros2_control/pull/938/files
![image](https://user-images.githubusercontent.com/31107191/225581301-2067bee4-5797-43a3-a1d5-9c830cd94904.png)
