### PR TITLE
Remove RHEL builds from PRs

### DIFF
--- a/.github/workflows/rolling-rhel-binary-build.yml
+++ b/.github/workflows/rolling-rhel-binary-build.yml
@@ -1,8 +1,6 @@
 name: Rolling RHEL Binary Build
 on:
-  pull_request:
-    branches:
-      - master
+  workflow_dispatch:
   push:
     branches:
       - master
@@ -17,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ROS_DISTRO: rolling
-    container: ghcr.io/ros-controls/ros:${{ env.ROS_DISTRO }}-rhel
+    container: ghcr.io/ros-controls/ros:rolling-rhel
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This workflow always failed -> I copied the configuration from https://github.com/ros-controls/ros2_control/pull/983

Do we need this here at all @bmagyar?