### PR TITLE
Update pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 ## General
-Please consider the infos from [CONTRIBUTING.md](CONTRIBUTING.md) before you open a pull request.
+Please consider the guidelines from [CONTRIBUTING.md](CONTRIBUTING.md) before you open a pull request.
 
 ## New Examples
 If you propose adding a new example, make sure that your new example has:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,8 @@
----
-name: Pull request
-about: Create a pull request
-title: ''
-labels: ''
-assignees: ''
-
----
 ## General
 Please consider the infos from [CONTRIBUTING.md](CONTRIBUTING.md) before you open a pull request.
+
 ## New Examples
-If you propose addign a new example, make sure that your new example has:
+If you propose adding a new example, make sure that your new example has:
 
 - [ ] The correct folder structure (described in the main [README.md](README.md))
 - [ ] Example has *doc/README.rst* with description


### PR DESCRIPTION
The last PR #265 did not fix the template. Maybe this has to be on a different path `.github/pull_request_template.md` if we don't use it with the `template` query parameter, see: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository