### PR TITLE
Fix github links on control.ros.org

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_control_demos/blob/|github_branch|/doc/index.rst
+
 .. _ros2_control_demos:
 
 #################

--- a/example_1/doc/userdoc.rst
+++ b/example_1/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_control_demos/blob/|github_branch|/example_1/doc/userdoc.rst
+
 .. _ros2_control_demos_example_1_userdoc:
 
 Example 1: RRBot

--- a/example_2/doc/userdoc.rst
+++ b/example_2/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_control_demos/blob/|github_branch|/example_2/doc/userdoc.rst
+
 .. _ros2_control_demos_example_2_userdoc:
 
 *********

--- a/example_3/doc/userdoc.rst
+++ b/example_3/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_control_demos/blob/|github_branch|/example_3/doc/userdoc.rst
+
 .. _ros2_control_demos_example_3_userdoc:
 
 ************************************************

--- a/example_4/doc/userdoc.rst
+++ b/example_4/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_control_demos/blob/|github_branch|/example_4/doc/userdoc.rst
+
 .. _ros2_control_demos_example_4_userdoc:
 
 ***************************************************

--- a/example_5/doc/userdoc.rst
+++ b/example_5/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_control_demos/blob/|github_branch|/example_5/doc/userdoc.rst
+
 .. _ros2_control_demos_example_5_userdoc:
 
 *************************************************************

--- a/example_6/doc/userdoc.rst
+++ b/example_6/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_control_demos/blob/|github_branch|/example_6/doc/userdoc.rst
+
 .. _ros2_control_demos_example_6_userdoc:
 
 ***********************************************************************

--- a/example_8/doc/userdoc.rst
+++ b/example_8/doc/userdoc.rst
@@ -1,3 +1,5 @@
+:github_url: https://github.com/ros-controls/ros2_control_demos/blob/|github_branch|/example_8/doc/userdoc.rst
+
 .. _ros2_control_demos_example_8_userdoc:
 
 ********************************************************************************


### PR DESCRIPTION
This is a companion PR to https://github.com/ros-controls/control.ros.org/pull/85. More details can be found there.