### PR TITLE
enable ReflowComments to also use ColumnLimit on comments

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -10,6 +10,6 @@ ConstructorInitializerIndentWidth: 0
 ContinuationIndentWidth: 2
 DerivePointerAlignment: false
 PointerAlignment: Middle
-ReflowComments: false
+ReflowComments: true
 IncludeBlocks: Preserve
 ...


### PR DESCRIPTION
Currently, as the ReflowComments are not enabled, the 100 columns limit is only applied to the code but not to the comments, and in the end, the CI checks are failing in this regard. By enabling the ReflowComments, this should be solved
