### PR TITLE
fix "ros2 invalid choice: 'launch'" by rosdep install

### DIFF
--- a/example_1/package.xml
+++ b/example_1/package.xml
@@ -20,6 +20,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
 
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_2/package.xml
+++ b/example_2/package.xml
@@ -20,6 +20,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
 
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>diff_drive_controller</exec_depend>

--- a/example_3/package.xml
+++ b/example_3/package.xml
@@ -18,6 +18,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
 
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_4/package.xml
+++ b/example_4/package.xml
@@ -18,6 +18,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
 
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_5/package.xml
+++ b/example_5/package.xml
@@ -18,6 +18,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
 
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_6/package.xml
+++ b/example_6/package.xml
@@ -18,6 +18,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
 
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_8/package.xml
+++ b/example_8/package.xml
@@ -21,6 +21,7 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>transmission_interface</depend>
 
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>


### PR DESCRIPTION
While trying to add dockerfiles for this repo it was throwing this:

```
ros2: error: argument Call `ros2 <command> -h` for more detailed usage.: invalid choice: 'launch'
```

Solution inspired by:
https://github.com/ros-controls/gz_ros2_control/blob/master/gz_ros2_control_demos/package.xml#L36

the other launch deps are not needed since they are already listed for ros2launch.