### PR TITLE
Add xacro as exec depend

### DIFF
--- a/.github/workflows/ci-format.yml
+++ b/.github/workflows/ci-format.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4.6.0
+    - uses: actions/setup-python@v4.6.1
       with:
         python-version: '3.10'
     - name: Install system hooks

--- a/example_1/package.xml
+++ b/example_1/package.xml
@@ -21,6 +21,7 @@
   <depend>rclcpp_lifecycle</depend>
 
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>xacro</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_1/package.xml
+++ b/example_1/package.xml
@@ -20,6 +20,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
 
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_2/package.xml
+++ b/example_2/package.xml
@@ -20,6 +20,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
 
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>diff_drive_controller</exec_depend>

--- a/example_2/package.xml
+++ b/example_2/package.xml
@@ -21,6 +21,7 @@
   <depend>rclcpp_lifecycle</depend>
 
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>xacro</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>diff_drive_controller</exec_depend>

--- a/example_3/package.xml
+++ b/example_3/package.xml
@@ -19,6 +19,7 @@
   <depend>rclcpp_lifecycle</depend>
 
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>xacro</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_3/package.xml
+++ b/example_3/package.xml
@@ -18,6 +18,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
 
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_4/package.xml
+++ b/example_4/package.xml
@@ -19,6 +19,7 @@
   <depend>rclcpp_lifecycle</depend>
 
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>xacro</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_4/package.xml
+++ b/example_4/package.xml
@@ -18,6 +18,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
 
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_5/package.xml
+++ b/example_5/package.xml
@@ -19,6 +19,7 @@
   <depend>rclcpp_lifecycle</depend>
 
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>xacro</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_5/package.xml
+++ b/example_5/package.xml
@@ -18,6 +18,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
 
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_6/package.xml
+++ b/example_6/package.xml
@@ -19,6 +19,7 @@
   <depend>rclcpp_lifecycle</depend>
 
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>xacro</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_6/package.xml
+++ b/example_6/package.xml
@@ -18,6 +18,7 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
 
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_8/package.xml
+++ b/example_8/package.xml
@@ -22,6 +22,7 @@
   <depend>transmission_interface</depend>
 
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>xacro</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>

--- a/example_8/package.xml
+++ b/example_8/package.xml
@@ -21,6 +21,7 @@
   <depend>rclcpp_lifecycle</depend>
   <depend>transmission_interface</depend>
 
+  <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>


### PR DESCRIPTION
Apologies for missing this.

resolves this issue:
```
root@d33280b944cb:/home/ros2_ws# ros2 launch ros2_control_demo_example_2 diffbot.launch.py 
[INFO] [launch]: All log files can be found below /root/.ros/log/2023-06-01-21-42-05-434293-d33280b944cb-83
[INFO] [launch]: Default logging verbosity is set to INFO
[ERROR] [launch]: Caught exception in launch (see debug for traceback): executable '[<launch.substitutions.text_substitution.TextSubstitution object at 0x7ff5141948b0>]' not found on the PATH
```

once again inspired by:
https://github.com/ros-controls/gz_ros2_control/blob/master/gz_ros2_control_demos/package.xml#L47

Also I checked all the examples so they should all be fine to run in docker using rosdep after this.