### PR TITLE
Remove outdated state_publish_rate for JTC

### DIFF
--- a/example_1/bringup/config/rrbot_controllers.yaml
+++ b/example_1/bringup/config/rrbot_controllers.yaml
@@ -32,7 +32,6 @@ joint_trajectory_position_controller:
     state_interfaces:
       - position
 
-    state_publish_rate: 200.0 # Defaults to 50
     action_monitor_rate: 20.0 # Defaults to 20
 
     allow_partial_joints_goal: false # Defaults to false


### PR DESCRIPTION
`state_publish_rate` was removed by https://github.com/ros-controls/ros2_controllers/pull/520/files