### PR TITLE
add a dependency; fix deprecation warning

### DIFF
--- a/example_1/bringup/launch/rrbot.launch.py
+++ b/example_1/bringup/launch/rrbot.launch.py
@@ -53,7 +53,8 @@ def generate_launch_description():
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_description, robot_controllers],
+        parameters=[robot_controllers],
+        remappings=[("~/robot_description", "/robot_description")],
         output="both",
     )
     robot_state_pub_node = Node(

--- a/example_1/package.xml
+++ b/example_1/package.xml
@@ -30,6 +30,7 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/example_2/bringup/launch/diffbot.launch.py
+++ b/example_2/bringup/launch/diffbot.launch.py
@@ -48,7 +48,8 @@ def generate_launch_description():
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_description, robot_controllers],
+        parameters=[robot_controllers],
+        remappings=[("~/robot_description", "/robot_description")],
         output="both",
     )
     robot_state_pub_node = Node(

--- a/example_2/package.xml
+++ b/example_2/package.xml
@@ -29,6 +29,7 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/example_3/bringup/launch/rrbot_base.launch.py
+++ b/example_3/bringup/launch/rrbot_base.launch.py
@@ -148,7 +148,8 @@ def generate_launch_description():
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_description, robot_controllers],
+        parameters=[robot_controllers],
+        remappings=[("~/robot_description", "/robot_description")],
         output="both",
     )
     robot_state_pub_node = Node(

--- a/example_3/package.xml
+++ b/example_3/package.xml
@@ -27,6 +27,7 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/example_4/bringup/launch/rrbot_base.launch.py
+++ b/example_4/bringup/launch/rrbot_base.launch.py
@@ -148,7 +148,8 @@ def generate_launch_description():
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_description, robot_controllers],
+        parameters=[robot_controllers],
+        remappings=[("~/robot_description", "/robot_description")],
         output="both",
     )
     robot_state_pub_node = Node(

--- a/example_4/package.xml
+++ b/example_4/package.xml
@@ -27,6 +27,7 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/example_5/bringup/launch/rrbot_base.launch.py
+++ b/example_5/bringup/launch/rrbot_base.launch.py
@@ -148,7 +148,8 @@ def generate_launch_description():
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_description, robot_controllers],
+        parameters=[robot_controllers],
+        remappings=[("~/robot_description", "/robot_description")],
         output="both",
     )
     robot_state_pub_node = Node(

--- a/example_5/package.xml
+++ b/example_5/package.xml
@@ -27,6 +27,7 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/example_6/bringup/launch/rrbot_base.launch.py
+++ b/example_6/bringup/launch/rrbot_base.launch.py
@@ -148,7 +148,8 @@ def generate_launch_description():
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_description, robot_controllers],
+        parameters=[robot_controllers],
+        remappings=[("~/robot_description", "/robot_description")],
         output="both",
     )
     robot_state_pub_node = Node(

--- a/example_6/package.xml
+++ b/example_6/package.xml
@@ -27,6 +27,7 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
 

--- a/example_8/bringup/launch/rrbot_base.launch.py
+++ b/example_8/bringup/launch/rrbot_base.launch.py
@@ -148,7 +148,8 @@ def generate_launch_description():
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_description, robot_controllers],
+        parameters=[robot_controllers],
+        remappings=[("~/robot_description", "/robot_description")],
         output="both",
     )
     robot_state_pub_node = Node(

--- a/example_8/package.xml
+++ b/example_8/package.xml
@@ -30,6 +30,7 @@
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
 


### PR DESCRIPTION
getting rid of this warning:
https://github.com/ros-controls/ros2_control/blob/master/controller_manager/src/controller_manager.cpp#L160C1-L167

and joint_state_publisher_gui wasn't installed when running view_robot.launch.py inside docker.