### PR TITLE
Fix ubuntu version for cpplint

### DIFF
--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -29,7 +29,7 @@ jobs:
 
   ament_lint_100:
     name: ament_${{ matrix.linter }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
ros-rolling-ament-cpplint seems not to be released for ubuntu 20.04 any more.