### PR TITLE
[CI] Bump ubuntu version of second ament_lint job

### DIFF
--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -5,11 +5,13 @@ on:
 jobs:
   ament_lint:
     name: ament_${{ matrix.linter }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
           linter: [copyright, cppcheck, lint_cmake]
+    env:
+      AMENT_CPPCHECK_ALLOW_SLOW_VERSIONS: true
     steps:
     - uses: actions/checkout@v3
     - uses: ros-tooling/setup-ros@v0.7


### PR DESCRIPTION
Follow-up to #330 Now, also copyright, cppcheck and lint_cmake fail.

`AMENT_CPPCHECK_ALLOW_SLOW_VERSIONS` needs to be set to run it.
