### PR TITLE
remove the arguments from update_reference_from_subscribers to backpo…

### DIFF
--- a/example_12/controllers/include/passthrough_controller/passthrough_controller.hpp
+++ b/example_12/controllers/include/passthrough_controller/passthrough_controller.hpp
@@ -71,8 +71,7 @@ public:
 protected:
   std::vector<hardware_interface::CommandInterface> on_export_reference_interfaces() override;
 
-  controller_interface::return_type update_reference_from_subscribers(
-    const rclcpp::Time & time, const rclcpp::Duration & period) override;
+  controller_interface::return_type update_reference_from_subscribers() override;
 
   std::shared_ptr<ParamListener> param_listener_;
   Params params_;

--- a/example_12/controllers/src/passthrough_controller.cpp
+++ b/example_12/controllers/src/passthrough_controller.cpp
@@ -157,8 +157,7 @@ PassthroughController::on_export_reference_interfaces()
   return reference_interfaces;
 }
 
-controller_interface::return_type PassthroughController::update_reference_from_subscribers(
-  const rclcpp::Time & /*time*/, const rclcpp::Duration & /*period*/)
+controller_interface::return_type PassthroughController::update_reference_from_subscribers()
 {
   auto joint_commands = rt_buffer_ptr_.readFromRT();
   // message is valid


### PR DESCRIPTION
A fix to be able to backport `example_12` to Humble
