### PR TITLE
Add info about ROS 2 distro

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Licence](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 This repository provides examples for functionalities and capabilities of `ros2_control` framework.
-It consists of simple implementations that demonstrate different concepts.
+It consists of simple implementations that demonstrate different concepts. Choose the right branch of this repository matching you ROS 2 distribution as well as the full documentation on [control.ros.org](https://control.ros.org), see [this table](#build-status).
 
 If you want to have rather step by step manual how to do things with `ros2_control` checkout the [ros-control/roscon2022_workshop](https://github.com/ros-controls/roscon2022_workshop) repository.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -76,12 +76,15 @@ Example 12: "Controller chaining"
 Installation
 =====================
 
-You can install the demos manually or use the provided docker file.
+You can install the demos locally or use the provided docker file.
 
-Manual Install
----------------
 
-First, you have to install `ROS 2 on your computer <https://docs.ros.org/en/rolling/Installation.html>`__.
+Local installation
+------------------
+
+If you have ROS 2 installed already, choose the right version of this documentation and branch of the ``ros2_control_demos`` repository matching you ROS 2 distribution, see `this table <https://github.com/ros-controls/ros2_control_demos#build-status>`__.
+
+Otherwise, install `ROS 2 {DISTRO} on your computer <https://docs.ros.org/en/rolling/Installation.html>`__.
 
 .. note::
 
@@ -98,7 +101,7 @@ Download the ``ros2_control_demos`` repository and install its dependencies with
 
   mkdir -p ~/ros2_ws/src
   cd ~/ros2_ws/src
-  git clone https://github.com/ros-controls/ros2_control_demos
+  git clone https://github.com/ros-controls/ros2_control_demos -b {REPOS_FILE_BRANCH}
   cd ~/ros2_ws/
   rosdep update --rosdistro=$ROS_DISTRO
   sudo apt-get update


### PR DESCRIPTION
Improve docs by adding explicit info about the ROS 2 distro, close #344.

rst for rolling will be rendered this way:
![image](https://github.com/ros-controls/ros2_control_demos/assets/3367244/8abe1ec7-8b45-46ba-becf-4fb4e2bc554b)
