### PR TITLE
Fix diffbot position integration

### DIFF
--- a/example_2/hardware/diffbot_system.cpp
+++ b/example_2/hardware/diffbot_system.cpp
@@ -180,7 +180,7 @@ hardware_interface::return_type DiffBotSystemHardware::read(
     // Simulate DiffBot wheels's movement as a first-order system
     // Update the joint status: this is a revolute joint without any limit.
     // Simply integrates
-    hw_positions_[i] = hw_positions_[1] + period.seconds() * hw_velocities_[i];
+    hw_positions_[i] = hw_positions_[i] + period.seconds() * hw_velocities_[i];
 
     RCLCPP_INFO(
       rclcpp::get_logger("DiffBotSystemHardware"),


### PR DESCRIPTION
The hardware interface for diffbot (example 2) integrates motor position data using the 2nd motor's position for both motors. This causes odometry to report movement along a single axis only. This PR fixes the issue and restores expected odometry behaviour.