### PR TITLE
Update docker instructions

### DIFF
--- a/Dockerfile/entrypoint.sh
+++ b/Dockerfile/entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 . /opt/ros/"${ROS_DISTRO}"/setup.sh
-. /home/ros2_ws/install/setup.sh
+cd /home/ros2_ws
+. install/setup.sh
 exec "$@"

--- a/doc/run_from_docker.rst
+++ b/doc/run_from_docker.rst
@@ -1,9 +1,3 @@
 .. note::
 
-   The commands below are given for a local installation of this repository and its dependencies. If you use the provided docker container, add the prefix
-
-   .. code::
-
-      docker run -it --rm --name ros2_control_demos --net host ros2_control_demos
-
-   to every command followed by a ``gui:=false``. For more information on the docker usage see :ref:`ros2_control_demos_install`.
+   The commands below are given for a local installation of this repository and its dependencies as well as for running them from a docker container. For more information on the docker usage see :ref:`doc/ros2_control_demos/doc/index:using docker`.

--- a/example_1/doc/userdoc.rst
+++ b/example_1/doc/userdoc.rst
@@ -70,6 +70,7 @@ Tutorial steps
     :width: 400
     :alt: Revolute-Revolute Manipulator Robot
 
+   Once it is working you can stop rviz using CTRL+C as the next launch file is starting RViz.
 
 2. To start *RRBot* example open a terminal, source your ROS2-workspace and execute its launch file with
 
@@ -97,9 +98,6 @@ Tutorial steps
 
    If you can see two orange and one yellow rectangle in *RViz* everything has started properly.
    Still, to be sure, let's introspect the control system before moving *RRBot*.
-   
-   Once it is working you can stop rviz using CTRL+C as the next launch file is starting RViz.
-
 
 3. Check if the hardware interface loaded properly, by opening another terminal and executing
 

--- a/example_1/doc/userdoc.rst
+++ b/example_1/doc/userdoc.rst
@@ -26,9 +26,38 @@ Tutorial steps
 
 1. To check that *RRBot* descriptions are working properly use following launch commands
 
-   .. code-block:: shell
+   .. tabs::
 
-    ros2 launch ros2_control_demo_example_1 view_robot.launch.py
+      .. group-tab:: Local
+
+         .. code-block:: shell
+
+           ros2 launch ros2_control_demo_example_1 view_robot.launch.py
+
+      .. group-tab:: Docker
+
+        Let's start with the docker container by running the following command:
+
+        .. code-block:: shell
+
+          docker run -it --rm --name ros2_control_demos --net host ros2_control_demos ros2 launch ros2_control_demo_example_1 view_robot.launch.py gui:=false
+
+        Now, we need to start ``joint_state_publisher_gui`` as well as ``rviz2`` to view the robot, each in their own terminals after sourcing our ROS 2 installation.
+
+        .. code-block:: shell
+
+          source /opt/ros/${ROS_DISTRO}/setup.bash
+          ros2 run joint_state_publisher_gui joint_state_publisher_gui
+
+        The *RViz* setup can be recreated following these steps:
+
+        * The robot models can be visualized using ``RobotModel`` display using ``/robot_description`` topic.
+        * Or you can simply open the configuration from ``ros2_control_demo_description/rrbot/rviz`` folder manually or directly by executing from another terminal
+
+        .. code-block:: shell
+
+          source /opt/ros/${ROS_DISTRO}/setup.bash
+          rviz2 -d src/ros2_control_demos/ros2_control_demo_description/rrbot/rviz/rrbot.rviz
 
    .. note::
 
@@ -41,23 +70,28 @@ Tutorial steps
     :width: 400
     :alt: Revolute-Revolute Manipulator Robot
 
-   The *RViz* setup can be recreated following these steps:
-
-   * The robot models can be visualized using ``RobotModel`` display using ``/robot_description`` topic.
-   * Or you can simply open the configuration from ``description/rviz`` folder manually or directly by executing
-
-   .. code-block:: shell
-
-    rviz2 --display-config `ros2 pkg prefix ros2_control_demo_example_1`/share/ros2_control_demo_example_1/rviz/rrbot.rviz
-
 
 2. To start *RRBot* example open a terminal, source your ROS2-workspace and execute its launch file with
 
-   .. code-block:: shell
+   .. tabs::
 
-    ros2 launch ros2_control_demo_example_1 rrbot.launch.py
+      .. group-tab:: Local
 
-   The launch file loads and starts the robot hardware, controllers and opens *RViz*.
+        .. code-block:: shell
+
+          ros2 launch ros2_control_demo_example_1 rrbot.launch.py
+
+        The launch file loads and starts the robot hardware, controllers and opens *RViz*.
+
+      .. group-tab:: Docker
+
+        .. code-block:: shell
+
+          docker run -it --rm --name ros2_control_demos --net host ros2_control_demos ros2 launch ros2_control_demo_example_1 rrbot.launch.py gui:=false
+
+        The launch file loads and starts the robot hardware and controllers. Open *RViz* in a new terminal
+        as described above.
+
    In starting terminal you will see a lot of output from the hardware implementation showing its internal states.
    This is only of exemplary purposes and should be avoided as much as possible in a hardware interface implementation.
 
@@ -66,9 +100,29 @@ Tutorial steps
 
 3. Check if the hardware interface loaded properly, by opening another terminal and executing
 
-   .. code-block:: shell
+   .. tabs::
 
-    ros2 control list_hardware_interfaces
+      .. group-tab:: Local
+
+        .. code-block:: shell
+
+          ros2 control list_hardware_interfaces
+
+      .. group-tab:: Docker
+
+        Open a bash terminal inside the already running docker container by
+
+        .. code-block:: shell
+
+          docker exec -it ros2_control_demos ./entrypoint.sh bash
+
+        and run the command
+
+        .. code-block:: shell
+
+          ros2 control list_hardware_interfaces
+
+   If everything started nominally, you should see the output
 
    .. code-block:: shell
 
@@ -83,9 +137,23 @@ Tutorial steps
 
 4. Check if controllers are running by
 
-   .. code-block:: shell
+   .. tabs::
 
-    ros2 control list_controllers
+      .. group-tab:: Local
+
+        .. code-block:: shell
+
+          ros2 control list_controllers
+
+      .. group-tab:: Docker
+
+        (from the docker terminal, see above)
+
+        .. code-block:: shell
+
+          ros2 control list_controllers
+
+   You will see the two controllers in active state
 
    .. code-block:: shell
 
@@ -96,17 +164,43 @@ Tutorial steps
 
    a. Manually using ROS 2 CLI interface:
 
-   .. code-block:: shell
+   .. tabs::
 
-    ros2 topic pub /forward_position_controller/commands std_msgs/msg/Float64MultiArray "data:
-    - 0.5
-    - 0.5"
+      .. group-tab:: Local
 
-   B. Or you can start a demo node which sends two goals every 5 seconds in a loop
+        .. code-block:: shell
 
-   .. code-block:: shell
+          ros2 topic pub /forward_position_controller/commands std_msgs/msg/Float64MultiArray "data:
+          - 0.5
+          - 0.5"
 
-    ros2 launch ros2_control_demo_example_1 test_forward_position_controller.launch.py
+      .. group-tab:: Docker
+
+        Inside the docker terminal from above, run the command
+
+        .. code-block:: shell
+
+          ros2 topic pub /forward_position_controller/commands std_msgs/msg/Float64MultiArray "data:
+          - 0.5
+          - 0.5"
+
+   B. Or you can start a demo node which sends two goals every 5 seconds in a loop:
+
+   .. tabs::
+
+      .. group-tab:: Local
+
+        .. code-block:: shell
+
+          ros2 launch ros2_control_demo_example_1 test_forward_position_controller.launch.py
+
+      .. group-tab:: Docker
+
+        Inside the docker terminal from above, run the command
+
+        .. code-block:: shell
+
+          ros2 launch ros2_control_demo_example_1 test_forward_position_controller.launch.py
 
    You should now see orange and yellow blocks moving in *RViz*.
    Also, you should see changing states in the terminal where launch file is started, e.g.
@@ -118,23 +212,61 @@ Tutorial steps
 
    If you echo the ``/joint_states`` or ``/dynamic_joint_states`` topics you should now get similar values, namely the simulated states of the robot
 
-   .. code-block:: shell
+   .. tabs::
 
-    ros2 topic echo /joint_states
-    ros2 topic echo /dynamic_joint_states
+      .. group-tab:: Local
+
+        .. code-block:: shell
+
+          ros2 topic echo /joint_states
+          ros2 topic echo /dynamic_joint_states
+
+      .. group-tab:: Docker
+
+        Inside the docker terminal from above, run the command
+
+        .. code-block:: shell
+
+          ros2 topic echo /joint_states
+          ros2 topic echo /dynamic_joint_states
+
 
 6. Let's switch to a different controller, the ``Joint Trajectory Controller``.
    Load the controller manually by
 
-   .. code-block:: shell
+   .. tabs::
 
-    ros2 control load_controller joint_trajectory_position_controller
+      .. group-tab:: Local
 
-   what should return ``Successfully loaded controller joint_trajectory_position_controller``. Check the status
+        .. code-block:: shell
 
-   .. code-block:: shell
+          ros2 control load_controller joint_trajectory_position_controller
 
-    ros2 control list_controllers
+      .. group-tab:: Docker
+
+        (from the docker terminal, see above)
+
+        .. code-block:: shell
+
+          ros2 control load_controller joint_trajectory_position_controller
+
+   what should return ``Successfully loaded controller joint_trajectory_position_controller``. Check the status with
+
+   .. tabs::
+
+      .. group-tab:: Local
+
+        .. code-block:: shell
+
+          ros2 control list_controllers
+
+      .. group-tab:: Docker
+
+        (from the docker terminal, see above)
+
+        .. code-block:: shell
+
+          ros2 control list_controllers
 
    what shows you that the controller is loaded but unconfigured.
 
@@ -146,9 +278,21 @@ Tutorial steps
 
    Configure the controller by setting it ``inactive`` by
 
-   .. code-block:: shell
+   .. tabs::
 
-    ros2 control set_controller_state joint_trajectory_position_controller inactive
+      .. group-tab:: Local
+
+        .. code-block:: shell
+
+          ros2 control set_controller_state joint_trajectory_position_controller inactive
+
+      .. group-tab:: Docker
+
+        (from the docker terminal, see above)
+
+        .. code-block:: shell
+
+          ros2 control set_controller_state joint_trajectory_position_controller inactive
 
    what should give ``Successfully configured joint_trajectory_position_controller``.
 
@@ -157,19 +301,43 @@ Tutorial steps
      The parameters are already set in `rrbot_controllers.yaml <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_1/bringup/config/rrbot_controllers.yaml>`__
      but the controller was not loaded from the `launch file rrbot.launch.py <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_1/bringup/launch/rrbot.launch.py>`__ before.
 
-   As an alternative, you can load the controller directly in ``inactive``-state by means of the option for ``load_controller``
+   As an alternative, you can load the controller directly in ``inactive``-state by means of the option for ``load_controller`` with
 
-   .. code-block:: shell
+   .. tabs::
 
-    ros2 control load_controller joint_trajectory_position_controller --set-state inactive
+      .. group-tab:: Local
+
+        .. code-block:: shell
+
+          ros2 control load_controller joint_trajectory_position_controller --set-state inactive
+
+      .. group-tab:: Docker
+
+        (from the docker terminal, see above)
+
+        .. code-block:: shell
+
+          ros2 control load_controller joint_trajectory_position_controller --set-state inactive
 
    You should get the result ``Successfully loaded controller joint_trajectory_position_controller into state inactive``.
 
    See if it loaded properly with
 
-   .. code-block:: shell
+   .. tabs::
 
-    ros2 control list_controllers
+      .. group-tab:: Local
+
+        .. code-block:: shell
+
+          ros2 control list_controllers
+
+      .. group-tab:: Docker
+
+        (from the docker terminal, see above)
+
+        .. code-block:: shell
+
+          ros2 control list_controllers
 
    what should now return
 
@@ -181,22 +349,59 @@ Tutorial steps
 
    Note that the controller is loaded but still ``inactive``. Now you can switch the controller by
 
-   .. code-block:: shell
+   .. tabs::
 
-    ros2 control set_controller_state forward_position_controller inactive
-    ros2 control set_controller_state joint_trajectory_position_controller active
+      .. group-tab:: Local
+
+        .. code-block:: shell
+
+          ros2 control set_controller_state forward_position_controller inactive
+          ros2 control set_controller_state joint_trajectory_position_controller active
+
+      .. group-tab:: Docker
+
+        (from the docker terminal, see above)
+
+        .. code-block:: shell
+
+          ros2 control set_controller_state forward_position_controller inactive
+          ros2 control set_controller_state joint_trajectory_position_controller active
 
    or simply via this one-line command
 
-   .. code-block:: shell
+   .. tabs::
 
-    ros2 control switch_controllers --activate joint_trajectory_position_controller --deactivate forward_position_controller
+      .. group-tab:: Local
+
+        .. code-block:: shell
+
+          ros2 control switch_controllers --activate joint_trajectory_position_controller --deactivate forward_position_controller
+
+      .. group-tab:: Docker
+
+        (from the docker terminal, see above)
+
+        .. code-block:: shell
+
+          ros2 control switch_controllers --activate joint_trajectory_position_controller --deactivate forward_position_controller
 
    Again, check via
 
-   .. code-block:: shell
+   .. tabs::
 
-    ros2 control list_controllers
+      .. group-tab:: Local
+
+        .. code-block:: shell
+
+          ros2 control list_controllers
+
+      .. group-tab:: Docker
+
+        (from the docker terminal, see above)
+
+        .. code-block:: shell
+
+          ros2 control list_controllers
 
    what should now return
 
@@ -206,11 +411,23 @@ Tutorial steps
     forward_position_controller[forward_command_controller/ForwardCommandController] inactive
     joint_trajectory_position_controller[joint_trajectory_controller/JointTrajectoryController] active
 
-   Send a command to the controller using demo node, which sends four goals every 6 seconds in a loop:
+   Send a command to the controller using demo node, which sends four goals every 6 seconds in a loop with
 
-   .. code-block:: shell
+   .. tabs::
 
-    ros2 launch ros2_control_demo_example_1 test_joint_trajectory_controller.launch.py
+      .. group-tab:: Local
+
+        .. code-block:: shell
+
+          ros2 launch ros2_control_demo_example_1 test_joint_trajectory_controller.launch.py
+
+      .. group-tab:: Docker
+
+        (from the docker terminal, see above)
+
+        .. code-block:: shell
+
+          ros2 launch ros2_control_demo_example_1 test_joint_trajectory_controller.launch.py
 
    You can adjust the goals in `rrbot_joint_trajectory_publisher <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_1/bringup/config/rrbot_joint_trajectory_publisher.yaml>`__.
 


### PR DESCRIPTION
Using the sphinx tabs plugin, we could improve the instructions using the docker container.

Choosing one tab switches all group-tabs at once (as known from docs.ros.org). What do you think? Did that only for example 1, but would apply the changes to the others, too.

![image](https://github.com/ros-controls/ros2_control_demos/assets/3367244/3e5cf77f-ac8b-4daa-a9ce-279b5f008114)
