### PR TITLE
Fix link

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -84,7 +84,7 @@ Local installation
 
 If you have ROS 2 installed already, choose the right version of this documentation and branch of the ``ros2_control_demos`` repository matching you ROS 2 distribution, see `this table <https://github.com/ros-controls/ros2_control_demos#build-status>`__.
 
-Otherwise, install `ROS 2 {DISTRO} on your computer <https://docs.ros.org/en/rolling/Installation.html>`__.
+Otherwise, install `ROS 2 {DISTRO} on your computer <https://docs.ros.org/en/{DISTRO}/Installation.html>`__.
 
 .. note::
 


### PR DESCRIPTION
Irrelevant on the master branch, but after backporting this will fix the link to the installation instructions of the correct distro.