### PR TITLE
Minor fixes in documentation (example_1 and example_12)

### DIFF
--- a/example_1/doc/userdoc.rst
+++ b/example_1/doc/userdoc.rst
@@ -24,7 +24,7 @@ The *RRBot* URDF files can be found in the ``description/urdf`` folder.
 Tutorial steps
 --------------------------
 
-1. To check that *RRBot* descriptions are working properly use following launch commands
+1. (Optional) To check that *RRBot* descriptions are working properly use following launch commands
 
    .. code-block:: shell
 
@@ -50,6 +50,7 @@ Tutorial steps
 
     rviz2 --display-config `ros2 pkg prefix ros2_control_demo_example_1`/share/ros2_control_demo_example_1/rviz/rrbot.rviz
 
+    Once it is working you can stop rviz using CTRL+C as the next launch file is starting RViz.
 
 2. To start *RRBot* example open a terminal, source your ROS2-workspace and execute its launch file with
 
@@ -61,7 +62,7 @@ Tutorial steps
    In starting terminal you will see a lot of output from the hardware implementation showing its internal states.
    This is only of exemplary purposes and should be avoided as much as possible in a hardware interface implementation.
 
-   If you can see two orange and one yellow rectangle in in *RViz* everything has started properly.
+   If you can see two orange and one yellow rectangle in *RViz* everything has started properly.
    Still, to be sure, let's introspect the control system before moving *RRBot*.
 
 3. Check if the hardware interface loaded properly, by opening another terminal and executing

--- a/example_12/README.md
+++ b/example_12/README.md
@@ -1,5 +1,5 @@
 # ros2_control_demo_example_12
 
-   This example demonstrates the switching between simulation and real hardware by means of the *RRBot* - or ''Revolute-Revolute Manipulator Robot''.
+   This example shows how to write a simple chainable controller, and how to integrate it properly to have a functional controller chaining.
 
 Find the documentation in [doc/userdoc.rst](doc/userdoc.rst) or on [control.ros.org](https://control.ros.org/master/doc/ros2_control_demos/example_12/doc/userdoc.html).


### PR DESCRIPTION
This PR is fixing simple stuff on top of the amazing recent work on documenting this repo. 

In example 1, the first step is optional and RViz should be closed, and the second step start also RViz. Plus there is two in as some point.

In example 12, the file README.md is giving the wrong title for the example.
