### PR TITLE
[Example 14] Fix return type of lambda

### DIFF
--- a/example_14/hardware/rrbot_sensor_for_position_feedback.cpp
+++ b/example_14/hardware/rrbot_sensor_for_position_feedback.cpp
@@ -164,6 +164,7 @@ hardware_interface::CallbackReturn RRBotSensorPositionFeedback::on_init(
         bzero(buffer, reading_size_bytes);
         std::this_thread::sleep_for(std::chrono::nanoseconds(1000000000 / incoming_data_read_rate));
       }
+      return hardware_interface::CallbackReturn::SUCCESS;
     });
   // END: This part here is for exemplary purposes - Please do not copy to your production code
 


### PR DESCRIPTION
As commented with #334, there was an missing return type of the lambda function.