### PR TITLE
Set default for use_mock_hardware

### DIFF
--- a/example_2/description/urdf/diffbot.urdf.xacro
+++ b/example_2/description/urdf/diffbot.urdf.xacro
@@ -2,6 +2,7 @@
 <!-- Basic differential drive mobile base -->
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="diffdrive_robot">
   <xacro:arg name="prefix" default="" />
+  <xacro:arg name="use_mock_hardware" default="false" />
 
   <xacro:include filename="$(find ros2_control_demo_description)/diffbot/urdf/diffbot_description.urdf.xacro" />
 


### PR DESCRIPTION
`ros2 launch ros2_control_demo_example_2 view_robot.launch.py` was broken, because argument `use_mock_hardware` wasn't set.