### PR TITLE
URDF: Add limits to the continuous joints

### DIFF
--- a/ros2_control_demo_description/diffbot/urdf/diffbot_description.urdf.xacro
+++ b/ros2_control_demo_description/diffbot/urdf/diffbot_description.urdf.xacro
@@ -49,6 +49,7 @@
       <origin xyz="0 -${base_width/2} ${z_offset}" rpy="0 0 0"/>
       <axis xyz="0 1 0"/>
       <dynamics damping="0.2"/>
+      <limit effort="100" velocity="1.0"/>
     </joint>
 
     <!-- left wheel Link -->
@@ -84,6 +85,7 @@
       <origin xyz="0 ${base_width/2} ${z_offset}" rpy="0 0 0"/>
       <axis xyz="0 1 0"/>
       <dynamics damping="0.2"/>
+      <limit effort="100" velocity="1.0"/>
     </joint>
 
     <!-- right wheel Link -->

--- a/ros2_control_demo_description/rrbot/urdf/rrbot_description.urdf.xacro
+++ b/ros2_control_demo_description/rrbot/urdf/rrbot_description.urdf.xacro
@@ -50,6 +50,7 @@
     <origin xyz="0 ${width} ${height1 - axel_offset}" rpy="0 0 0"/>
     <axis xyz="0 1 0"/>
     <dynamics damping="0.7"/>
+    <limit effort="100" velocity="1.0"/>
   </joint>
 
   <!-- Middle Link -->
@@ -85,6 +86,7 @@
     <origin xyz="0 ${width} ${height2 - axel_offset*2}" rpy="0 0 0"/>
     <axis xyz="0 1 0"/>
     <dynamics damping="0.7"/>
+    <limit effort="100" velocity="1.0"/>
   </joint>
 
   <!-- Top Link -->


### PR DESCRIPTION
While testing rqt_joint_trajectory_controller we realized that the URDFs lack limits for the continuous joints (velocity + effort). 