### PR TITLE
Publish correct joint velocities in r6bot example 7

### DIFF
--- a/example_7/reference_generator/send_trajectory.cpp
+++ b/example_7/reference_generator/send_trajectory.cpp
@@ -81,7 +81,7 @@ int main(int argc, char ** argv)
       trajectory_point_msg.positions.data(), joint_positions.data.data(),
       trajectory_point_msg.positions.size() * sizeof(double));
     std::memcpy(
-      trajectory_point_msg.velocities.data(), joint_positions.data.data(),
+      trajectory_point_msg.velocities.data(), joint_velocities.data.data(),
       trajectory_point_msg.velocities.size() * sizeof(double));
 
     // integrate joint velocities


### PR DESCRIPTION
Resolves #427 by copying joint velocities into the trajectory point's velocity field. This makes no functional difference for the r6bot controller when both position and velocity are provided as shown by @christophfroehlich [here](https://github.com/ros-controls/ros2_control_demos/issues/427#issuecomment-1891645903).

Tested by echoing the `/r6bot_controller/joint_trajectory` topic. Prior to the change, both `velocities` and `positions` were always the same:
```
...
- positions:
  - 0.2526216532445078
  - -0.21062744421529653
  - -0.3485843399000512
  - -0.13795689568475478
  - -1.2928197138013211e-16
  - 0.25262165324450775
  velocities:
  - 0.2526216532445078
  - -0.21062744421529653
  - -0.3485843399000512
  - -0.13795689568475478
  - -1.2928197138013211e-16
  - 0.25262165324450775
  accelerations: []
  effort: []
  time_from_start:
    sec: 1
    nanosec: 924242424
...
```

After the change, the `velocities` and `positions` differ:
```
...
- positions:
  - 0.2526216532445078
  - -0.21062744421529653
  - -0.3485843399000512
  - -0.13795689568475478
  - -1.2928197138013211e-16
  - 0.25262165324450775
  velocities:
  - 0.37845782334674916
  - 0.47486669652093844
  - 0.719777222778079
  - 0.24491052625714027
  - -8.847089727481716e-17
  - 0.37845782334674904
  accelerations: []
  effort: []
  time_from_start:
    sec: 1
    nanosec: 924242424
...
```

No difference in the example is observed.