### PR TITLE
[CI] Add ref checkout for scheduled docker builds

### DIFF
--- a/.github/workflows/humble-docker-build.yaml
+++ b/.github/workflows/humble-docker-build.yaml
@@ -18,5 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: humble
     - name: Build the Docker image
-      run: docker build . --file Dockerfile/Dockerfile --tag ros2_control_demos_humble
+      run: docker build --file Dockerfile/Dockerfile --tag ros2_control_demos_humble --build-arg ROS_DISTRO=humble .

--- a/.github/workflows/iron-docker-build.yaml
+++ b/.github/workflows/iron-docker-build.yaml
@@ -18,5 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: iron
     - name: Build the Docker image
-      run: docker build . --file Dockerfile/Dockerfile --tag ros2_control_demos_iron
+      run: docker build --file Dockerfile/Dockerfile --tag ros2_control_demos_iron --build-arg ROS_DISTRO=iron .

--- a/.github/workflows/rolling-docker-build.yaml
+++ b/.github/workflows/rolling-docker-build.yaml
@@ -18,5 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: master
     - name: Build the Docker image
-      run: docker build . --file Dockerfile/Dockerfile --tag ros2_control_demos_rolling
+      run: docker build --file Dockerfile/Dockerfile --tag ros2_control_demos_rolling --build-arg ROS_DISTRO=rolling .


### PR DESCRIPTION
Scheduled build always runs from the default branch, i.e., we have to specify the branch for the checkout
https://github.com/ros-controls/ros2_control_demos/actions/runs/8197668059/job/22419968638