### PR TITLE
Give the controller type as parameter in ctrl namespace

### DIFF
--- a/example_1/bringup/config/rrbot_controllers.yaml
+++ b/example_1/bringup/config/rrbot_controllers.yaml
@@ -5,15 +5,10 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    forward_position_controller:
-      type: forward_command_controller/ForwardCommandController
-
-    joint_trajectory_position_controller:
-      type: joint_trajectory_controller/JointTrajectoryController
-
 
 forward_position_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - joint1
       - joint2
@@ -22,6 +17,8 @@ forward_position_controller:
 
 joint_trajectory_position_controller:
   ros__parameters:
+    type: joint_trajectory_controller/JointTrajectoryController
+
     joints:
       - joint1
       - joint2

--- a/example_1/bringup/launch/rrbot.launch.py
+++ b/example_1/bringup/launch/rrbot.launch.py
@@ -88,13 +88,13 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["joint_state_broadcaster"],
     )
 
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["forward_position_controller", "--controller-manager", "/controller_manager"],
+        arguments=["forward_position_controller", "--param-file", robot_controllers],
     )
 
     # Delay rviz start after `joint_state_broadcaster`

--- a/example_10/bringup/config/rrbot_controllers.yaml
+++ b/example_10/bringup/config/rrbot_controllers.yaml
@@ -5,15 +5,10 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    forward_position_controller:
-      type: forward_command_controller/ForwardCommandController
-
-    gpio_controller:
-      type: ros2_control_demo_example_10/GPIOController
-
 
 forward_position_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - joint1
       - joint2
@@ -21,6 +16,7 @@ forward_position_controller:
 
 gpio_controller:
   ros__parameters:
+    type: ros2_control_demo_example_10/GPIOController
     inputs:
      - flange_analog_IOs/analog_output1
      - flange_analog_IOs/analog_input1

--- a/example_10/bringup/launch/rrbot.launch.py
+++ b/example_10/bringup/launch/rrbot.launch.py
@@ -78,19 +78,19 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["joint_state_broadcaster"],
     )
 
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["forward_position_controller", "-c", "/controller_manager"],
+        arguments=["forward_position_controller", "--param-file", robot_controllers],
     )
 
     gpio_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["gpio_controller", "-c", "/controller_manager"],
+        arguments=["gpio_controller", "--param-file", robot_controllers],
     )
 
     # Delay start of robot_controller after `joint_state_broadcaster`

--- a/example_11/bringup/config/carlikebot_controllers.yaml
+++ b/example_11/bringup/config/carlikebot_controllers.yaml
@@ -5,12 +5,10 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    bicycle_steering_controller:
-      type: bicycle_steering_controller/BicycleSteeringController
-
 
 bicycle_steering_controller:
   ros__parameters:
+    type: bicycle_steering_controller/BicycleSteeringController
     wheelbase: 0.325
     front_wheel_radius: 0.05
     rear_wheel_radius: 0.05

--- a/example_11/bringup/launch/carlikebot.launch.py
+++ b/example_11/bringup/launch/carlikebot.launch.py
@@ -108,13 +108,13 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["joint_state_broadcaster"],
     )
 
     robot_bicycle_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["bicycle_steering_controller", "--controller-manager", "/controller_manager"],
+        arguments=["bicycle_steering_controller", "--param-file", robot_controllers],
     )
 
     # Delay rviz start after `joint_state_broadcaster`

--- a/example_12/bringup/config/rrbot_chained_controllers.yaml
+++ b/example_12/bringup/config/rrbot_chained_controllers.yaml
@@ -5,32 +5,22 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    joint1_position_controller:
-      type: passthrough_controller/PassthroughController
-
-    joint2_position_controller:
-      type: passthrough_controller/PassthroughController
-
-    position_controller:
-      type: passthrough_controller/PassthroughController
-
-    forward_position_controller:
-      type: forward_command_controller/ForwardCommandController
 
 # First-level controllers
 joint1_position_controller:
   ros__parameters:
+    type: passthrough_controller/PassthroughController
     interfaces: ["joint1/position"]
-
 
 joint2_position_controller:
   ros__parameters:
+    type: passthrough_controller/PassthroughController
     interfaces: ["joint2/position"]
-
 
 # Second-level controller
 position_controller:
   ros__parameters:
+    type: passthrough_controller/PassthroughController
     interfaces:
       - joint1_position_controller/joint1/position
       - joint2_position_controller/joint2/position
@@ -38,6 +28,7 @@ position_controller:
 # Third-level controllers
 forward_position_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - position_controller/joint1_position_controller/joint1
       - position_controller/joint2_position_controller/joint2

--- a/example_12/bringup/launch/launch_chained_controllers.launch.py
+++ b/example_12/bringup/launch/launch_chained_controllers.launch.py
@@ -16,21 +16,31 @@
 from launch import LaunchDescription
 from launch.actions import RegisterEventHandler
 from launch.event_handlers import OnProcessExit
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
 
+    robot_controllers = PathJoinSubstitution(
+        [
+            FindPackageShare("ros2_control_demo_example_12"),
+            "config",
+            "rrbot_chained_controllers.yaml",
+        ]
+    )
+
     position_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["position_controller", "--controller-manager", "/controller_manager"],
+        arguments=["position_controller", "--param-file", robot_controllers],
     )
 
     forward_position_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["forward_position_controller", "--controller-manager", "/controller_manager"],
+        arguments=["forward_position_controller", "--param-file", robot_controllers],
     )
 
     # Delay start of forward_position_controller_spawner after `position_controller_spawner`

--- a/example_12/bringup/launch/rrbot.launch.py
+++ b/example_12/bringup/launch/rrbot.launch.py
@@ -73,19 +73,19 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["joint_state_broadcaster"],
     )
 
     j1_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint1_position_controller", "--controller-manager", "/controller_manager"],
+        arguments=["joint1_position_controller", "--param-file", robot_controllers],
     )
 
     j2_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint2_position_controller", "--controller-manager", "/controller_manager"],
+        arguments=["joint2_position_controller", "--param-file", robot_controllers],
     )
 
     # Delay rviz start after `joint_state_broadcaster`

--- a/example_14/bringup/config/rrbot_modular_actuators_without_feedback_sensors_for_position_feedback.yaml
+++ b/example_14/bringup/config/rrbot_modular_actuators_without_feedback_sensors_for_position_feedback.yaml
@@ -5,12 +5,10 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    forward_velocity_controller:
-      type: forward_command_controller/ForwardCommandController
-
 
 forward_velocity_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - joint1
       - joint2

--- a/example_14/bringup/launch/rrbot_modular_actuators_without_feedback_sensors_for_position_feedback.launch.py
+++ b/example_14/bringup/launch/rrbot_modular_actuators_without_feedback_sensors_for_position_feedback.launch.py
@@ -117,13 +117,13 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["joint_state_broadcaster"],
     )
 
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=[robot_controller, "--controller-manager", "/controller_manager"],
+        arguments=[robot_controller, "--param-file", robot_controllers],
     )
 
     # Delay rviz start after `joint_state_broadcaster`

--- a/example_15/bringup/config/multi_controller_manager_rrbot_1_controllers.yaml
+++ b/example_15/bringup/config/multi_controller_manager_rrbot_1_controllers.yaml
@@ -6,7 +6,7 @@
       type: joint_state_broadcaster/JointStateBroadcaster
 
 
-forward_position_controller:
+/rrbot_1/forward_position_controller:
   ros__parameters:
     type: forward_command_controller/ForwardCommandController
     joints:
@@ -15,7 +15,7 @@ forward_position_controller:
     interface_name: position
 
 
-position_trajectory_controller:
+/rrbot_1/position_trajectory_controller:
   ros__parameters:
     type: joint_trajectory_controller/JointTrajectoryController
     joints:

--- a/example_15/bringup/config/multi_controller_manager_rrbot_1_controllers.yaml
+++ b/example_15/bringup/config/multi_controller_manager_rrbot_1_controllers.yaml
@@ -6,7 +6,7 @@
       type: joint_state_broadcaster/JointStateBroadcaster
 
 
-/rrbot_1/forward_position_controller:
+forward_position_controller:
   ros__parameters:
     type: forward_command_controller/ForwardCommandController
     joints:
@@ -15,7 +15,7 @@
     interface_name: position
 
 
-/rrbot_1/position_trajectory_controller:
+position_trajectory_controller:
   ros__parameters:
     type: joint_trajectory_controller/JointTrajectoryController
     joints:

--- a/example_15/bringup/config/multi_controller_manager_rrbot_1_controllers.yaml
+++ b/example_15/bringup/config/multi_controller_manager_rrbot_1_controllers.yaml
@@ -5,15 +5,10 @@
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    forward_position_controller:
-      type: forward_command_controller/ForwardCommandController
-
-    position_trajectory_controller:
-      type: joint_trajectory_controller/JointTrajectoryController
-
 
 /rrbot_1/forward_position_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - rrbot_1_joint1
       - rrbot_1_joint2
@@ -22,6 +17,7 @@
 
 /rrbot_1/position_trajectory_controller:
   ros__parameters:
+    type: joint_trajectory_controller/JointTrajectoryController
     joints:
       - rrbot_1_joint1
       - rrbot_1_joint2

--- a/example_15/bringup/config/multi_controller_manager_rrbot_2_controllers.yaml
+++ b/example_15/bringup/config/multi_controller_manager_rrbot_2_controllers.yaml
@@ -6,7 +6,7 @@
       type: joint_state_broadcaster/JointStateBroadcaster
 
 
-forward_position_controller:
+/rrbot_2/forward_position_controller:
   ros__parameters:
     type: forward_command_controller/ForwardCommandController
     joints:
@@ -15,7 +15,7 @@ forward_position_controller:
     interface_name: position
 
 
-position_trajectory_controller:
+/rrbot_2/position_trajectory_controller:
   ros__parameters:
     type: joint_trajectory_controller/JointTrajectoryController
     joints:

--- a/example_15/bringup/config/multi_controller_manager_rrbot_2_controllers.yaml
+++ b/example_15/bringup/config/multi_controller_manager_rrbot_2_controllers.yaml
@@ -6,7 +6,7 @@
       type: joint_state_broadcaster/JointStateBroadcaster
 
 
-/rrbot_2/forward_position_controller:
+forward_position_controller:
   ros__parameters:
     type: forward_command_controller/ForwardCommandController
     joints:
@@ -15,7 +15,7 @@
     interface_name: position
 
 
-/rrbot_2/position_trajectory_controller:
+position_trajectory_controller:
   ros__parameters:
     type: joint_trajectory_controller/JointTrajectoryController
     joints:

--- a/example_15/bringup/config/multi_controller_manager_rrbot_2_controllers.yaml
+++ b/example_15/bringup/config/multi_controller_manager_rrbot_2_controllers.yaml
@@ -5,15 +5,10 @@
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    forward_position_controller:
-      type: forward_command_controller/ForwardCommandController
-
-    position_trajectory_controller:
-      type: joint_trajectory_controller/JointTrajectoryController
-
 
 /rrbot_2/forward_position_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - rrbot_2_joint1
       - rrbot_2_joint2
@@ -22,6 +17,7 @@
 
 /rrbot_2/position_trajectory_controller:
   ros__parameters:
+    type: joint_trajectory_controller/JointTrajectoryController
     joints:
       - rrbot_2_joint1
       - rrbot_2_joint2

--- a/example_15/bringup/config/rrbot_namespace_controllers.yaml
+++ b/example_15/bringup/config/rrbot_namespace_controllers.yaml
@@ -6,7 +6,7 @@
       type: joint_state_broadcaster/JointStateBroadcaster
 
 
-/rrbot/forward_position_controller:
+forward_position_controller:
   ros__parameters:
     type: forward_command_controller/ForwardCommandController
     joints:
@@ -15,7 +15,7 @@
     interface_name: position
 
 
-/rrbot/position_trajectory_controller:
+position_trajectory_controller:
   ros__parameters:
     type: joint_trajectory_controller/JointTrajectoryController
     joints:

--- a/example_15/bringup/config/rrbot_namespace_controllers.yaml
+++ b/example_15/bringup/config/rrbot_namespace_controllers.yaml
@@ -5,15 +5,10 @@
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    forward_position_controller:
-      type: forward_command_controller/ForwardCommandController
-
-    position_trajectory_controller:
-      type: joint_trajectory_controller/JointTrajectoryController
-
 
 /rrbot/forward_position_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - joint1
       - joint2
@@ -22,6 +17,7 @@
 
 /rrbot/position_trajectory_controller:
   ros__parameters:
+    type: joint_trajectory_controller/JointTrajectoryController
     joints:
       - joint1
       - joint2

--- a/example_15/bringup/config/rrbot_namespace_controllers.yaml
+++ b/example_15/bringup/config/rrbot_namespace_controllers.yaml
@@ -6,7 +6,7 @@
       type: joint_state_broadcaster/JointStateBroadcaster
 
 
-forward_position_controller:
+/rrbot/forward_position_controller:
   ros__parameters:
     type: forward_command_controller/ForwardCommandController
     joints:
@@ -15,7 +15,7 @@ forward_position_controller:
     interface_name: position
 
 
-position_trajectory_controller:
+/rrbot/position_trajectory_controller:
   ros__parameters:
     type: joint_trajectory_controller/JointTrajectoryController
     joints:

--- a/example_15/bringup/launch/multi_controller_manager_example_two_rrbots.launch.py
+++ b/example_15/bringup/launch/multi_controller_manager_example_two_rrbots.launch.py
@@ -79,11 +79,18 @@ def generate_launch_description():
     rrbot_1_position_trajectory_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
+        namespace="rrbot_1",
         arguments=[
             "position_trajectory_controller",
-            "-c",
-            "/rrbot_1/controller_manager",
             "--inactive",
+            "--param-file",
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("ros2_control_demo_example_15"),
+                    "config",
+                    "multi_controller_manager_rrbot_1_controllers.yaml",
+                ]
+            ),
         ],
     )
 
@@ -108,11 +115,18 @@ def generate_launch_description():
     rrbot_2_position_trajectory_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
+        namespace="rrbot_2",
         arguments=[
             "position_trajectory_controller",
-            "-c",
-            "/rrbot_2/controller_manager",
             "--inactive",
+            "--param-file",
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("ros2_control_demo_example_15"),
+                    "config",
+                    "multi_controller_manager_rrbot_2_controllers.yaml",
+                ]
+            ),
         ],
     )
 

--- a/example_15/bringup/launch/rrbot_base.launch.py
+++ b/example_15/bringup/launch/rrbot_base.launch.py
@@ -209,7 +209,13 @@ def generate_launch_description():
         package="controller_manager",
         executable="spawner",
         namespace=namespace,
-        arguments=[robot_controller, "-c", controller_manager_name],
+        arguments=[
+            robot_controller,
+            "-c",
+            controller_manager_name,
+            "--param-file",
+            robot_controllers,
+        ],
     )
 
     # Delay rviz start after `joint_state_broadcaster`

--- a/example_15/bringup/launch/rrbot_namespace.launch.py
+++ b/example_15/bringup/launch/rrbot_namespace.launch.py
@@ -84,23 +84,26 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "-c", "/rrbot/controller_manager"],
+        namespace="rrbot",
+        arguments=["joint_state_broadcaster"],
     )
 
     robot_forward_position_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["forward_position_controller", "-c", "/rrbot/controller_manager"],
+        namespace="rrbot",
+        arguments=["forward_position_controller", "--param-file", robot_controllers],
     )
 
     robot_position_trajectory_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
+        namespace="rrbot",
         arguments=[
             "position_trajectory_controller",
-            "-c",
-            "/rrbot/controller_manager",
             "--inactive",
+            "--param-file",
+            robot_controllers,
         ],
     )
 

--- a/example_2/bringup/config/diffbot_controllers.yaml
+++ b/example_2/bringup/config/diffbot_controllers.yaml
@@ -5,11 +5,10 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    diffbot_base_controller:
-      type: diff_drive_controller/DiffDriveController
-
 diffbot_base_controller:
   ros__parameters:
+    type: diff_drive_controller/DiffDriveController
+
     left_wheel_names: ["left_wheel_joint"]
     right_wheel_names: ["right_wheel_joint"]
 

--- a/example_2/bringup/launch/diffbot.launch.py
+++ b/example_2/bringup/launch/diffbot.launch.py
@@ -97,13 +97,13 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["joint_state_broadcaster"],
     )
 
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["diffbot_base_controller", "--controller-manager", "/controller_manager"],
+        arguments=["diffbot_base_controller", "--param-file", robot_controllers],
     )
 
     # Delay rviz start after `joint_state_broadcaster`

--- a/example_3/bringup/config/rrbot_multi_interface_forward_controllers.yaml
+++ b/example_3/bringup/config/rrbot_multi_interface_forward_controllers.yaml
@@ -2,38 +2,26 @@ controller_manager:
   ros__parameters:
     update_rate: 100  # Hz
 
-    forward_position_controller:
-      type: position_controllers/JointGroupPositionController
-
-    forward_velocity_controller:
-      type: velocity_controllers/JointGroupVelocityController
-
-    forward_acceleration_controller:
-      type: forward_command_controller/ForwardCommandController
-
-    forward_illegal1_controller:
-      type: forward_command_controller/ForwardCommandController
-
-    forward_illegal2_controller:
-      type: forward_command_controller/ForwardCommandController
-
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
 forward_position_controller:
   ros__parameters:
+    type: position_controllers/JointGroupPositionController
     joints:
       - joint1
       - joint2
 
 forward_velocity_controller:
   ros__parameters:
+    type: velocity_controllers/JointGroupVelocityController
     joints:
       - joint1
       - joint2
 
 forward_acceleration_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - joint1
       - joint2
@@ -41,12 +29,14 @@ forward_acceleration_controller:
 
 forward_illegal1_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - joint1
     interface_name: position
 
 forward_illegal2_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - joint2
     interface_name: position

--- a/example_3/bringup/launch/rrbot_system_multi_interface.launch.py
+++ b/example_3/bringup/launch/rrbot_system_multi_interface.launch.py
@@ -140,13 +140,13 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["joint_state_broadcaster"],
     )
 
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=[robot_controller, "--controller-manager", "/controller_manager"],
+        arguments=[robot_controller, "--param-file", robot_controllers],
     )
 
     # Delay rviz start after `joint_state_broadcaster`

--- a/example_4/bringup/config/rrbot_with_sensor_controllers.yaml
+++ b/example_4/bringup/config/rrbot_with_sensor_controllers.yaml
@@ -2,17 +2,12 @@ controller_manager:
   ros__parameters:
     update_rate: 100  # Hz
 
-    forward_position_controller:
-      type: forward_command_controller/ForwardCommandController
-
-    fts_broadcaster:
-      type: force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
-
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
 forward_position_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - joint1
       - joint2
@@ -20,6 +15,7 @@ forward_position_controller:
 
 fts_broadcaster:
   ros__parameters:
+    type: force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
     interface_names.force.x: tcp_fts_sensor/force.x
     interface_names.torque.z: tcp_fts_sensor/torque.z
     frame_id: tool_link

--- a/example_4/bringup/launch/rrbot_system_with_sensor.launch.py
+++ b/example_4/bringup/launch/rrbot_system_with_sensor.launch.py
@@ -132,20 +132,20 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["joint_state_broadcaster"],
     )
 
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["forward_position_controller", "--controller-manager", "/controller_manager"],
+        arguments=["forward_position_controller", "--param-file", robot_controllers],
     )
 
     # add the spawner node for the fts_broadcaster
     fts_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["fts_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["fts_broadcaster", "--param-file", robot_controllers],
     )
 
     # Delay rviz start after `joint_state_broadcaster`

--- a/example_5/bringup/config/rrbot_with_external_sensor_controllers.yaml
+++ b/example_5/bringup/config/rrbot_with_external_sensor_controllers.yaml
@@ -2,17 +2,12 @@ controller_manager:
   ros__parameters:
     update_rate: 100  # Hz
 
-    forward_position_controller:
-      type: forward_command_controller/ForwardCommandController
-
-    fts_broadcaster:
-      type: force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
-
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
 forward_position_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - joint1
       - joint2
@@ -20,5 +15,6 @@ forward_position_controller:
 
 fts_broadcaster:
   ros__parameters:
+    type: force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
     sensor_name: tcp_fts_sensor
     frame_id: tool_link

--- a/example_5/bringup/launch/rrbot_system_with_external_sensor.launch.py
+++ b/example_5/bringup/launch/rrbot_system_with_external_sensor.launch.py
@@ -145,7 +145,7 @@ def generate_launch_description():
     fts_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["fts_broadcaster" "--param-file", robot_controllers],
+        arguments=["fts_broadcaster", "--param-file", robot_controllers],
     )
 
     # Delay rviz start after `joint_state_broadcaster`

--- a/example_5/bringup/launch/rrbot_system_with_external_sensor.launch.py
+++ b/example_5/bringup/launch/rrbot_system_with_external_sensor.launch.py
@@ -132,20 +132,20 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["joint_state_broadcaster"],
     )
 
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["forward_position_controller", "--controller-manager", "/controller_manager"],
+        arguments=["forward_position_controller", "--param-file", robot_controllers],
     )
 
     # add the spawner node for the fts_broadcaster
     fts_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["fts_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["fts_broadcaster" "--param-file", robot_controllers],
     )
 
     # Delay rviz start after `joint_state_broadcaster`

--- a/example_6/bringup/config/rrbot_modular_actuators.yaml
+++ b/example_6/bringup/config/rrbot_modular_actuators.yaml
@@ -5,12 +5,10 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    forward_position_controller:
-      type: forward_command_controller/ForwardCommandController
-
 
 forward_position_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - joint1
       - joint2

--- a/example_6/bringup/launch/rrbot_modular_actuators.launch.py
+++ b/example_6/bringup/launch/rrbot_modular_actuators.launch.py
@@ -140,13 +140,13 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["joint_state_broadcaster"],
     )
 
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=[robot_controller, "--controller-manager", "/controller_manager"],
+        arguments=[robot_controller, "--param-file", robot_controllers],
     )
 
     # Delay rviz start after `joint_state_broadcaster`

--- a/example_7/bringup/config/r6bot_controller.yaml
+++ b/example_7/bringup/config/r6bot_controller.yaml
@@ -5,12 +5,10 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    r6bot_controller:
-      type: ros2_control_demo_example_7/RobotController
-
 
 r6bot_controller:
   ros__parameters:
+    type: ros2_control_demo_example_7/RobotController
     joints:
       - joint_1
       - joint_2

--- a/example_7/bringup/launch/r6bot_controller.launch.py
+++ b/example_7/bringup/launch/r6bot_controller.launch.py
@@ -78,13 +78,13 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["joint_state_broadcaster"],
     )
 
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["r6bot_controller", "-c", "/controller_manager"],
+        arguments=["r6bot_controller", "--param-file", robot_controllers],
     )
 
     # Delay rviz start after `joint_state_broadcaster`

--- a/example_8/bringup/config/rrbot_controllers.yaml
+++ b/example_8/bringup/config/rrbot_controllers.yaml
@@ -5,12 +5,10 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    forward_position_controller:
-      type: forward_command_controller/ForwardCommandController
-
 
 forward_position_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - joint1
       - joint2

--- a/example_8/bringup/launch/rrbot_transmissions_system_position_only.launch.py
+++ b/example_8/bringup/launch/rrbot_transmissions_system_position_only.launch.py
@@ -117,13 +117,13 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["joint_state_broadcaster"],
     )
 
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=[robot_controller, "--controller-manager", "/controller_manager"],
+        arguments=[robot_controller, "--param-file", robot_controllers],
     )
 
     # Delay rviz start after `joint_state_broadcaster`

--- a/example_9/bringup/config/rrbot_controllers.yaml
+++ b/example_9/bringup/config/rrbot_controllers.yaml
@@ -5,11 +5,10 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    forward_position_controller:
-      type: forward_command_controller/ForwardCommandController
 
 forward_position_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - joint1
       - joint2

--- a/example_9/bringup/launch/rrbot.launch.py
+++ b/example_9/bringup/launch/rrbot.launch.py
@@ -89,13 +89,13 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["joint_state_broadcaster"],
     )
 
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["forward_position_controller", "--controller-manager", "/controller_manager"],
+        arguments=["forward_position_controller", "--param-file", robot_controllers],
     )
 
     # Delay rviz start after `joint_state_broadcaster`

--- a/example_9/bringup/launch/rrbot_gazebo.launch.py
+++ b/example_9/bringup/launch/rrbot_gazebo.launch.py
@@ -71,6 +71,15 @@ def generate_launch_description():
         ]
     )
     robot_description = {"robot_description": robot_description_content}
+
+    robot_controllers = PathJoinSubstitution(
+        [
+            FindPackageShare("ros2_control_demo_example_9"),
+            "config",
+            "rrbot_controllers.yaml",
+        ]
+    )
+
     rviz_config_file = PathJoinSubstitution(
         [FindPackageShare("ros2_control_demo_description"), "rrbot/rviz", "rrbot.rviz"]
     )
@@ -85,13 +94,13 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster", "--controller-manager", "/controller_manager"],
+        arguments=["joint_state_broadcaster"],
     )
 
     robot_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["forward_position_controller", "--controller-manager", "/controller_manager"],
+        arguments=["forward_position_controller", "--param-file", robot_controllers],
     )
     rviz_node = Node(
         package="rviz2",


### PR DESCRIPTION
This changes the location of declaring the controller type, which will be possible with https://github.com/ros-controls/ros2_control/pull/1502

I tried to write it consistently: 

- Controller types without parameters are declared in the controller_manager namespace (joint_state_broadcaster)
- Others are declared in the controllers' namespaces, which is considered to be best-practice from now on.