### PR TITLE
[doc] Remove a duplicate hint

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -250,7 +250,6 @@ These are some quick hints, especially for those coming from a ROS1 control back
   * *ros(1)_control* only allowed three hardware interface types: position, velocity, and effort.
     *ros2_control* allows you to create any interface type by defining a custom string. For example, you might define a ``position_in_degrees`` or a ``temperature`` interface.
     The most common (position, velocity, acceleration, effort) are already defined as constants in hardware_interface/types/hardware_interface_type_values.hpp.
-  * Joint names in <ros2_control> tags in the URDF must be compatible with the controller's configuration.
   * In ros2_control, all parameters for the driver are specified in the URDF.
     The ros2_control framework uses the **<ros2_control>** tag in the URDF.
   * Joint names in <ros2_control> tags in the URDF must be compatible with the controller's configuration.


### PR DESCRIPTION
## General

That hint repeats 2 times. 
I've removed one of them:

> * Joint names in <ros2_control> tags in the URDF must be compatible with the controller's configuration.

[here](https://control.ros.org/master/doc/ros2_control_demos/doc/index.html#quick-hints)

(It can be backported to humble as well)