### PR TITLE
[doc] fix typo in example_7 - remove `[]()`

### DIFF
--- a/example_7/doc/userdoc.rst
+++ b/example_7/doc/userdoc.rst
@@ -379,7 +379,7 @@ The ``on_init`` method is called immediately after the controller plugin is dyna
 
 .. code-block:: c++
 
-  using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;[]()
+  using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
   controller_interface::CallbackReturn on_init(){
       // declare and get parameters needed for controller initialization


### PR DESCRIPTION
## General

I've removed `[]()` from the end [here](https://control.ros.org/master/doc/ros2_control_demos/example_7/doc/userdoc.html#writing-a-controller):
```cpp
using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;[]()
```
I don't think that's a valid C++ syntax (sorry, I'm a beginner in C++). Also, because [the actual code](https://github.com/ros-controls/ros2_control_demos/blob/436d3c61dfa8ccf4a810a85c702c542d1540aeba/example_7/hardware/include/ros2_control_demo_example_7/r6bot_hardware.hpp#L32) doesn't have `[]()`


(This change can be backported to Humble & Iron)