### PR TITLE
Remove stamped parameter

### DIFF
--- a/example_11/bringup/config/carlikebot_controllers.yaml
+++ b/example_11/bringup/config/carlikebot_controllers.yaml
@@ -26,4 +26,3 @@ bicycle_steering_controller:
     twist_covariance_diagonal: [0.0, 7.0, 14.0, 21.0, 28.0, 35.0]
     pose_covariance_diagonal: [0.0, 7.0, 14.0, 21.0, 28.0, 35.0]
     position_feedback: false
-    use_stamped_vel: true


### PR DESCRIPTION
Is default true already, and will be removed by https://github.com/ros-controls/ros2_controllers/pull/1151 