### PR TITLE
Add launch tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
-.kdev4/
-
-
-*~
-*.kate-swp
-*.kdev4
+.ccache
+.work

--- a/example_1/CMakeLists.txt
+++ b/example_1/CMakeLists.txt
@@ -17,6 +17,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # find dependencies
+find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/example_1/CMakeLists.txt
+++ b/example_1/CMakeLists.txt
@@ -66,6 +66,7 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(example_1_urdf_xacro test/test_urdf_xacro.py)
   ament_add_pytest_test(view_example_1_launch test/test_view_robot_launch.py)
+  ament_add_pytest_test(run_example_1_launch test/test_rrbot_launch.py)
 endif()
 
 

--- a/example_1/bringup/launch/rrbot.launch.py
+++ b/example_1/bringup/launch/rrbot.launch.py
@@ -105,20 +105,21 @@ def generate_launch_description():
         )
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_joint_state_broadcaster_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[robot_controller_spawner],
+            target_action=robot_controller_spawner,
+            on_exit=[joint_state_broadcaster_spawner],
         )
     )
 
     nodes = [
         control_node,
         robot_state_pub_node,
-        joint_state_broadcaster_spawner,
+        robot_controller_spawner,
         delay_rviz_after_joint_state_broadcaster_spawner,
-        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
+        delay_joint_state_broadcaster_after_robot_controller_spawner,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/example_1/package.xml
+++ b/example_1/package.xml
@@ -34,9 +34,9 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
+  <test_depend>ros2_control_demo_testing</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/example_1/package.xml
+++ b/example_1/package.xml
@@ -15,6 +15,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/example_1/test/test_rrbot_launch.py
+++ b/example_1/test/test_rrbot_launch.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import os
+import pytest
+import unittest
+import time
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+
+# import launch_testing.markers
+from launch_testing_ros import WaitForTopics
+from controller_manager.controller_manager_services import list_controllers
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("ros2_control_demo_example_1"),
+                "launch/rrbot.launch.py",
+            )
+        ),
+        launch_arguments={"gui": "true"}.items(),
+    )
+
+    return LaunchDescription([launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "robot_state_publisher" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "robot_state_publisher not found!"
+
+    def test_controller_running(self, proc_output):
+
+        cname = "forward_position_controller"
+
+        start = time.time()
+        found = False
+        while time.time() - start < 10.0 and not found:
+            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                if c.name == cname and c.state == "active":
+                    found = True
+                    break
+        assert found, f"{cname} not found!"
+
+    def test_check_if_msgs_published(self):
+        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 2, "Wrong number of joints in message"
+        assert msg.name == ["joint1", "joint2"], "Wrong joint names"
+        wait_for_topics.shutdown()
+
+
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
+
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_1/test/test_rrbot_launch.py
+++ b/example_1/test/test_rrbot_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,11 +91,10 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_1/test/test_rrbot_launch.py
+++ b/example_1/test/test_rrbot_launch.py
@@ -40,11 +40,9 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
-from launch_testing_ros import WaitForTopics
-from controller_manager.controller_manager_services import list_controllers
 import rclpy
 from rclpy.node import Node
-from sensor_msgs.msg import JointState
+from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -78,34 +76,19 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         start = time.time()
         found = False
-        while time.time() - start < 2.0 and not found:
+        while time.time() - start < 5.0 and not found:
             found = "robot_state_publisher" in self.node.get_node_names()
             time.sleep(0.1)
         assert found, "robot_state_publisher not found!"
 
     def test_controller_running(self, proc_output):
 
-        cname = "forward_position_controller"
+        cnames = ["forward_position_controller", "joint_state_broadcaster"]
 
-        start = time.time()
-        found = False
-        while time.time() - start < 10.0 and not found:
-            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
-            assert controllers, "No controllers found!"
-            for c in controllers:
-                if c.name == cname and c.state == "active":
-                    found = True
-                    break
-        assert found, f"{cname} not found!"
+        check_controllers_running(self.node, cnames)
 
     def test_check_if_msgs_published(self):
-        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
-        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
-        msgs = wait_for_topics.received_messages("/joint_states")
-        msg = msgs[0]
-        assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
-        wait_for_topics.shutdown()
+        check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore

--- a/example_1/test/test_rrbot_launch.py
+++ b/example_1/test/test_rrbot_launch.py
@@ -104,7 +104,7 @@ class TestFixture(unittest.TestCase):
         msgs = wait_for_topics.received_messages("/joint_states")
         msg = msgs[0]
         assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert msg.name == ["joint1", "joint2"], "Wrong joint names"
+        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
         wait_for_topics.shutdown()
 
 

--- a/example_1/test/test_rrbot_launch.py
+++ b/example_1/test/test_rrbot_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-import launch_testing.markers
+# import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,10 +91,11 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-@launch_testing.post_shutdown_test()
-# These tests are run after the processes in generate_test_description() have shutdown.
-class TestDescriptionCraneShutdown(unittest.TestCase):
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
 
-    def test_exit_codes(self, proc_info):
-        """Check if the processes exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info)
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_1/test/test_rrbot_launch.py
+++ b/example_1/test/test_rrbot_launch.py
@@ -31,7 +31,6 @@
 import os
 import pytest
 import unittest
-import time
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -42,7 +41,11 @@ from launch_testing.actions import ReadyToTest
 # import launch_testing.markers
 import rclpy
 from rclpy.node import Node
-from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
+from ros2_control_demo_testing.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -74,12 +77,7 @@ class TestFixture(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running(self, proc_output):
 

--- a/example_1/test/test_rrbot_launch.py
+++ b/example_1/test/test_rrbot_launch.py
@@ -57,7 +57,7 @@ def generate_test_description():
                 "launch/rrbot.launch.py",
             )
         ),
-        launch_arguments={"gui": "true"}.items(),
+        launch_arguments={"gui": "False"}.items(),
     )
 
     return LaunchDescription([launch_include, ReadyToTest()])

--- a/example_10/CMakeLists.txt
+++ b/example_10/CMakeLists.txt
@@ -20,6 +20,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # find dependencies
+find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/example_10/CMakeLists.txt
+++ b/example_10/CMakeLists.txt
@@ -77,6 +77,7 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(example_10_urdf_xacro test/test_urdf_xacro.py)
   ament_add_pytest_test(view_example_10_launch test/test_view_robot_launch.py)
+  ament_add_pytest_test(run_example_10_launch test/test_rrbot_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_10/bringup/launch/rrbot.launch.py
+++ b/example_10/bringup/launch/rrbot.launch.py
@@ -93,20 +93,27 @@ def generate_launch_description():
         arguments=["gpio_controller", "-c", "/controller_manager"],
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_gpio_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[robot_controller_spawner],
+            target_action=robot_controller_spawner,
+            on_exit=[gpio_controller_spawner],
+        )
+    )
+    delay_joint_state_broadcaster_after_gpio_controller_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=gpio_controller_spawner,
+            on_exit=[joint_state_broadcaster_spawner],
         )
     )
 
     nodes = [
         control_node,
         robot_state_pub_node,
-        joint_state_broadcaster_spawner,
-        gpio_controller_spawner,
-        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
+        robot_controller_spawner,
+        delay_gpio_after_robot_controller_spawner,
+        delay_joint_state_broadcaster_after_gpio_controller_spawner,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/example_10/package.xml
+++ b/example_10/package.xml
@@ -33,7 +33,6 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>ros2_control_demo_testing</test_depend>

--- a/example_10/package.xml
+++ b/example_10/package.xml
@@ -15,6 +15,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/example_10/package.xml
+++ b/example_10/package.xml
@@ -32,11 +32,11 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
+  <test_depend>ros2_control_demo_testing</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/example_10/test/test_rrbot_launch.py
+++ b/example_10/test/test_rrbot_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,11 +91,10 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_10/test/test_rrbot_launch.py
+++ b/example_10/test/test_rrbot_launch.py
@@ -31,7 +31,6 @@
 import os
 import pytest
 import unittest
-import time
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -42,7 +41,11 @@ from launch_testing.actions import ReadyToTest
 import launch_testing
 import rclpy
 from rclpy.node import Node
-from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
+from ros2_control_demo_testing.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
 
 
 # This function specifies the processes to be run for our test
@@ -79,12 +82,7 @@ class TestFixture(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running(self, proc_output):
 

--- a/example_10/test/test_rrbot_launch.py
+++ b/example_10/test/test_rrbot_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published

--- a/example_10/test/test_rrbot_launch.py
+++ b/example_10/test/test_rrbot_launch.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import os
+import pytest
+import unittest
+import time
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+
+# import launch_testing.markers
+from launch_testing_ros import WaitForTopics
+from controller_manager.controller_manager_services import list_controllers
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+# This function specifies the processes to be run for our test
+@pytest.mark.launch_test
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("ros2_control_demo_example_10"),
+                "launch/rrbot.launch.py",
+            )
+        ),
+        launch_arguments={"gui": "false"}.items(),
+    )
+
+    return LaunchDescription([launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "robot_state_publisher" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "robot_state_publisher not found!"
+
+    def test_controller_running(self, proc_output):
+
+        cnames = ["forward_position_controller", "gpio_controller", "joint_state_broadcaster"]
+        found = {cname: False for cname in cnames}  # Define 'found' as a dictionary
+
+        start = time.time()
+        while time.time() - start < 10.0 and not all(found.values()):
+            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                for cname in cnames:
+                    if c.name == cname and c.state == "active":
+                        found[cname] = True
+                        break
+
+        assert all(
+            found.values()
+        ), f"Controller(s) not found: {', '.join([cname for cname, is_found in found.items() if not is_found])}"
+
+    def test_check_if_msgs_published(self):
+        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 2, "Wrong number of joints in message"
+        assert msg.name == ["joint1", "joint2"], "Wrong joint names"
+        wait_for_topics.shutdown()
+
+
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
+
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_10/test/test_rrbot_launch.py
+++ b/example_10/test/test_rrbot_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-import launch_testing.markers
+# import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -96,10 +96,11 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-@launch_testing.post_shutdown_test()
-# These tests are run after the processes in generate_test_description() have shutdown.
-class TestDescriptionCraneShutdown(unittest.TestCase):
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
 
-    def test_exit_codes(self, proc_info):
-        """Check if the processes exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info)
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_10/test/test_rrbot_launch.py
+++ b/example_10/test/test_rrbot_launch.py
@@ -40,11 +40,9 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
-from launch_testing_ros import WaitForTopics
-from controller_manager.controller_manager_services import list_controllers
 import rclpy
 from rclpy.node import Node
-from sensor_msgs.msg import JointState
+from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
 
 
 # This function specifies the processes to be run for our test
@@ -78,7 +76,7 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         start = time.time()
         found = False
-        while time.time() - start < 2.0 and not found:
+        while time.time() - start < 5.0 and not found:
             found = "robot_state_publisher" in self.node.get_node_names()
             time.sleep(0.1)
         assert found, "robot_state_publisher not found!"
@@ -86,30 +84,11 @@ class TestFixture(unittest.TestCase):
     def test_controller_running(self, proc_output):
 
         cnames = ["forward_position_controller", "gpio_controller", "joint_state_broadcaster"]
-        found = {cname: False for cname in cnames}  # Define 'found' as a dictionary
 
-        start = time.time()
-        while time.time() - start < 10.0 and not all(found.values()):
-            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
-            assert controllers, "No controllers found!"
-            for c in controllers:
-                for cname in cnames:
-                    if c.name == cname and c.state == "active":
-                        found[cname] = True
-                        break
-
-        assert all(
-            found.values()
-        ), f"Controller(s) not found: {', '.join([cname for cname, is_found in found.items() if not is_found])}"
+        check_controllers_running(self.node, cnames)
 
     def test_check_if_msgs_published(self):
-        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
-        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
-        msgs = wait_for_topics.received_messages("/joint_states")
-        msg = msgs[0]
-        assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert msg.name == ["joint1", "joint2"], "Wrong joint names"
-        wait_for_topics.shutdown()
+        check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore

--- a/example_10/test/test_rrbot_launch.py
+++ b/example_10/test/test_rrbot_launch.py
@@ -46,7 +46,12 @@ from ros2_control_demo_testing.test_utils import check_controllers_running, chec
 
 
 # This function specifies the processes to be run for our test
+# The ReadyToTest action waits for 15 second by default for the processes to
+# start, if processes take more time an error is thrown. We use decorator here
+# to provide timeout duration of 20 second so that processes that take longer than
+# 15 seconds can start up.
 @pytest.mark.launch_test
+@launch_testing.ready_to_test_action_timeout(20)
 def generate_test_description():
     launch_include = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(

--- a/example_11/CMakeLists.txt
+++ b/example_11/CMakeLists.txt
@@ -17,6 +17,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # find dependencies
+find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/example_11/CMakeLists.txt
+++ b/example_11/CMakeLists.txt
@@ -66,6 +66,7 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(example_11_urdf_xacro test/test_urdf_xacro.py)
   ament_add_pytest_test(view_example_11_launch test/test_view_robot_launch.py)
+  ament_add_pytest_test(run_example_11_launch test/test_carlikebot_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_11/bringup/launch/carlikebot.launch.py
+++ b/example_11/bringup/launch/carlikebot.launch.py
@@ -125,11 +125,12 @@ def generate_launch_description():
         )
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_joint_state_broadcaster_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[robot_bicycle_controller_spawner],
+            target_action=robot_bicycle_controller_spawner,
+            on_exit=[joint_state_broadcaster_spawner],
         )
     )
 
@@ -137,9 +138,9 @@ def generate_launch_description():
         control_node,
         control_node_remapped,
         robot_state_pub_bicycle_node,
-        joint_state_broadcaster_spawner,
+        robot_bicycle_controller_spawner,
+        delay_joint_state_broadcaster_after_robot_controller_spawner,
         delay_rviz_after_joint_state_broadcaster_spawner,
-        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/example_11/package.xml
+++ b/example_11/package.xml
@@ -15,6 +15,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/example_11/package.xml
+++ b/example_11/package.xml
@@ -31,7 +31,12 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
+  <test_depend>liburdfdom-tools</test_depend>
+  <test_depend>ros2_control_demo_testing</test_depend>
+  <test_depend>xacro</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/example_11/package.xml
+++ b/example_11/package.xml
@@ -32,7 +32,6 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>ros2_control_demo_testing</test_depend>

--- a/example_11/test/test_carlikebot_launch.py
+++ b/example_11/test/test_carlikebot_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -97,11 +97,10 @@ class TestFixture(unittest.TestCase):
         )
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_11/test/test_carlikebot_launch.py
+++ b/example_11/test/test_carlikebot_launch.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import os
+import pytest
+import unittest
+import time
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+
+# import launch_testing.markers
+from launch_testing_ros import WaitForTopics
+from controller_manager.controller_manager_services import list_controllers
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("ros2_control_demo_example_11"),
+                "launch/carlikebot.launch.py",
+            )
+        ),
+        launch_arguments={"gui": "false"}.items(),
+    )
+
+    return LaunchDescription([launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "robot_state_publisher" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "robot_state_publisher not found!"
+
+    def test_controller_running(self, proc_output):
+
+        cname = "bicycle_steering_controller"
+
+        start = time.time()
+        found = False
+        while time.time() - start < 10.0 and not found:
+            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                if c.name == cname and c.state == "active":
+                    found = True
+                    break
+        assert found, f"{cname} not found!"
+
+    def test_check_if_msgs_published(self):
+        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 2, "Wrong number of joints in message"
+        assert msg.name == [
+            "virtual_front_wheel_joint",
+            "virtual_rear_wheel_joint",
+        ], "Wrong joint names"
+        wait_for_topics.shutdown()
+
+
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
+
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_11/test/test_carlikebot_launch.py
+++ b/example_11/test/test_carlikebot_launch.py
@@ -31,7 +31,6 @@
 import os
 import pytest
 import unittest
-import time
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -42,7 +41,11 @@ from launch_testing.actions import ReadyToTest
 # import launch_testing.markers
 import rclpy
 from rclpy.node import Node
-from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
+from ros2_control_demo_testing.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -74,12 +77,7 @@ class TestFixture(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running(self, proc_output):
 

--- a/example_11/test/test_carlikebot_launch.py
+++ b/example_11/test/test_carlikebot_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-import launch_testing.markers
+# import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -97,10 +97,11 @@ class TestFixture(unittest.TestCase):
         )
 
 
-@launch_testing.post_shutdown_test()
-# These tests are run after the processes in generate_test_description() have shutdown.
-class TestDescriptionCraneShutdown(unittest.TestCase):
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
 
-    def test_exit_codes(self, proc_info):
-        """Check if the processes exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info)
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_12/CMakeLists.txt
+++ b/example_12/CMakeLists.txt
@@ -23,6 +23,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # find dependencies
+find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/example_12/CMakeLists.txt
+++ b/example_12/CMakeLists.txt
@@ -104,6 +104,7 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(example_12_urdf_xacro test/test_urdf_xacro.py)
   ament_add_pytest_test(view_example_12_launch test/test_view_robot_launch.py)
+  ament_add_pytest_test(run_example_12_launch test/test_rrbot_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_12/bringup/launch/rrbot.launch.py
+++ b/example_12/bringup/launch/rrbot.launch.py
@@ -14,15 +14,29 @@
 
 
 from launch import LaunchDescription
-from launch.actions import RegisterEventHandler
+from launch.actions import DeclareLaunchArgument, RegisterEventHandler
+from launch.conditions import IfCondition
 from launch.event_handlers import OnProcessExit
-from launch.substitutions import Command, FindExecutable, PathJoinSubstitution
+from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, LaunchConfiguration
 
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
+    # Declare arguments
+    declared_arguments = []
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "gui",
+            default_value="true",
+            description="Start RViz2 automatically with this launch file.",
+        )
+    )
+
+    # Initialize Arguments
+    gui = LaunchConfiguration("gui")
+
     # Get URDF via xacro
     robot_description_content = Command(
         [
@@ -68,6 +82,7 @@ def generate_launch_description():
         name="rviz2",
         output="log",
         arguments=["-d", rviz_config_file],
+        condition=IfCondition(gui),
     )
 
     joint_state_broadcaster_spawner = Node(
@@ -112,4 +127,4 @@ def generate_launch_description():
         delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
     ]
 
-    return LaunchDescription(nodes)
+    return LaunchDescription(declared_arguments + nodes)

--- a/example_12/bringup/launch/rrbot.launch.py
+++ b/example_12/bringup/launch/rrbot.launch.py
@@ -111,20 +111,22 @@ def generate_launch_description():
         )
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_joint_state_broadcaster_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[j1_controller_spawner, j2_controller_spawner],
+            target_action=j1_controller_spawner,
+            on_exit=[joint_state_broadcaster_spawner],
         )
     )
 
     nodes = [
         control_node,
         robot_state_pub_node,
-        joint_state_broadcaster_spawner,
+        j1_controller_spawner,
+        j2_controller_spawner,
         delay_rviz_after_joint_state_broadcaster_spawner,
-        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
+        delay_joint_state_broadcaster_after_robot_controller_spawner,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/example_12/package.xml
+++ b/example_12/package.xml
@@ -34,7 +34,6 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>ros2_control_demo_testing</test_depend>

--- a/example_12/package.xml
+++ b/example_12/package.xml
@@ -16,6 +16,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/example_12/package.xml
+++ b/example_12/package.xml
@@ -33,11 +33,11 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
+  <test_depend>ros2_control_demo_testing</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/example_12/test/test_rrbot_launch.py
+++ b/example_12/test/test_rrbot_launch.py
@@ -41,11 +41,9 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
-from launch_testing_ros import WaitForTopics
-from controller_manager.controller_manager_services import list_controllers
 import rclpy
 from rclpy.node import Node
-from sensor_msgs.msg import JointState
+from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -79,7 +77,7 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         start = time.time()
         found = False
-        while time.time() - start < 2.0 and not found:
+        while time.time() - start < 5.0 and not found:
             found = "robot_state_publisher" in self.node.get_node_names()
             time.sleep(0.1)
         assert found, "robot_state_publisher not found!"
@@ -91,30 +89,11 @@ class TestFixture(unittest.TestCase):
             "joint2_position_controller",
             "joint_state_broadcaster",
         ]
-        found = {cname: False for cname in cnames}  # Define 'found' as a dictionary
 
-        start = time.time()
-        while time.time() - start < 10.0 and not all(found.values()):
-            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
-            assert controllers, "No controllers found!"
-            for c in controllers:
-                for cname in cnames:
-                    if c.name == cname and c.state == "active":
-                        found[cname] = True
-                        break
-
-        assert all(
-            found.values()
-        ), f"Controller(s) not found: {', '.join([cname for cname, is_found in found.items() if not is_found])}"
+        check_controllers_running(self.node, cnames)
 
     def test_check_if_msgs_published(self):
-        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
-        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
-        msgs = wait_for_topics.received_messages("/joint_states")
-        msg = msgs[0]
-        assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert msg.name == ["joint1", "joint2"], "Wrong joint names"
-        wait_for_topics.shutdown()
+        check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
 # This is our second test fixture. Each method is a test case.
@@ -141,7 +120,7 @@ class TestFixtureChained(unittest.TestCase):
     def test_node_start(self, proc_output):
         start = time.time()
         found = False
-        while time.time() - start < 2.0 and not found:
+        while time.time() - start < 5.0 and not found:
             found = "robot_state_publisher" in self.node.get_node_names()
             time.sleep(0.1)
         assert found, "robot_state_publisher not found!"
@@ -155,30 +134,11 @@ class TestFixtureChained(unittest.TestCase):
             "position_controller",
             "forward_position_controller",
         ]
-        found = {cname: False for cname in cnames}  # Define 'found' as a dictionary
 
-        start = time.time()
-        while time.time() - start < 10.0 and not all(found.values()):
-            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
-            assert controllers, "No controllers found!"
-            for c in controllers:
-                for cname in cnames:
-                    if c.name == cname and c.state == "active":
-                        found[cname] = True
-                        break
-
-        assert all(
-            found.values()
-        ), f"Controller(s) not found: {', '.join([cname for cname, is_found in found.items() if not is_found])}"
+        check_controllers_running(self.node, cnames)
 
     def test_check_if_msgs_published(self):
-        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
-        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
-        msgs = wait_for_topics.received_messages("/joint_states")
-        msg = msgs[0]
-        assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert msg.name == ["joint1", "joint2"], "Wrong joint names"
-        wait_for_topics.shutdown()
+        check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore

--- a/example_12/test/test_rrbot_launch.py
+++ b/example_12/test/test_rrbot_launch.py
@@ -40,7 +40,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -141,11 +141,10 @@ class TestFixtureChained(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_12/test/test_rrbot_launch.py
+++ b/example_12/test/test_rrbot_launch.py
@@ -40,7 +40,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-import launch_testing.markers
+# import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -141,10 +141,11 @@ class TestFixtureChained(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-@launch_testing.post_shutdown_test()
-# These tests are run after the processes in generate_test_description() have shutdown.
-class TestDescriptionCraneShutdown(unittest.TestCase):
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
 
-    def test_exit_codes(self, proc_info):
-        """Check if the processes exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info)
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_12/test/test_rrbot_launch.py
+++ b/example_12/test/test_rrbot_launch.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import os
+import pytest
+import unittest
+import time
+import subprocess
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+
+# import launch_testing.markers
+from launch_testing_ros import WaitForTopics
+from controller_manager.controller_manager_services import list_controllers
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("ros2_control_demo_example_12"),
+                "launch/rrbot.launch.py",
+            )
+        ),
+        launch_arguments={"gui": "false"}.items(),
+    )
+
+    return LaunchDescription([launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "robot_state_publisher" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "robot_state_publisher not found!"
+
+    def test_controller_running(self, proc_output):
+
+        cnames = [
+            "joint1_position_controller",
+            "joint2_position_controller",
+            "joint_state_broadcaster",
+        ]
+        found = {cname: False for cname in cnames}  # Define 'found' as a dictionary
+
+        start = time.time()
+        while time.time() - start < 10.0 and not all(found.values()):
+            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                for cname in cnames:
+                    if c.name == cname and c.state == "active":
+                        found[cname] = True
+                        break
+
+        assert all(
+            found.values()
+        ), f"Controller(s) not found: {', '.join([cname for cname, is_found in found.items() if not is_found])}"
+
+    def test_check_if_msgs_published(self):
+        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 2, "Wrong number of joints in message"
+        assert msg.name == ["joint1", "joint2"], "Wrong joint names"
+        wait_for_topics.shutdown()
+
+
+# This is our second test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixtureChained(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+        # Command to run the launch file
+        command = [
+            "ros2",
+            "launch",
+            "ros2_control_demo_example_12",
+            "launch_chained_controllers.launch.py",
+        ]
+        # Execute the command
+        subprocess.run(command)
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "robot_state_publisher" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "robot_state_publisher not found!"
+
+    def test_controller_running(self, proc_output):
+
+        cnames = [
+            "joint1_position_controller",
+            "joint2_position_controller",
+            "joint_state_broadcaster",
+            "position_controller",
+            "forward_position_controller",
+        ]
+        found = {cname: False for cname in cnames}  # Define 'found' as a dictionary
+
+        start = time.time()
+        while time.time() - start < 10.0 and not all(found.values()):
+            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                for cname in cnames:
+                    if c.name == cname and c.state == "active":
+                        found[cname] = True
+                        break
+
+        assert all(
+            found.values()
+        ), f"Controller(s) not found: {', '.join([cname for cname, is_found in found.items() if not is_found])}"
+
+    def test_check_if_msgs_published(self):
+        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 2, "Wrong number of joints in message"
+        assert msg.name == ["joint1", "joint2"], "Wrong joint names"
+        wait_for_topics.shutdown()
+
+
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
+
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_12/test/test_rrbot_launch.py
+++ b/example_12/test/test_rrbot_launch.py
@@ -31,7 +31,6 @@
 import os
 import pytest
 import unittest
-import time
 import subprocess
 
 from ament_index_python.packages import get_package_share_directory
@@ -43,7 +42,11 @@ from launch_testing.actions import ReadyToTest
 # import launch_testing.markers
 import rclpy
 from rclpy.node import Node
-from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
+from ros2_control_demo_testing.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -75,12 +78,7 @@ class TestFixture(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running(self, proc_output):
 
@@ -118,12 +116,7 @@ class TestFixtureChained(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running(self, proc_output):
 

--- a/example_14/CMakeLists.txt
+++ b/example_14/CMakeLists.txt
@@ -18,6 +18,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # find dependencies
+find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/example_14/CMakeLists.txt
+++ b/example_14/CMakeLists.txt
@@ -64,7 +64,11 @@ install(TARGETS ros2_control_demo_example_14
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_cmake_pytest REQUIRED)
+
+  ament_add_pytest_test(example_14_urdf_xacro test/test_urdf_xacro.py)
+  ament_add_pytest_test(view_example_14_launch test/test_view_robot_launch.py)
+  ament_add_pytest_test(run_example_14_launch test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_14/bringup/config/rrbot_modular_actuators_without_feedback_sensors_for_position_feedback.yaml
+++ b/example_14/bringup/config/rrbot_modular_actuators_without_feedback_sensors_for_position_feedback.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 100  # Hz
+    update_rate: 10  # Hz
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster

--- a/example_14/bringup/launch/rrbot_modular_actuators_without_feedback_sensors_for_position_feedback.launch.py
+++ b/example_14/bringup/launch/rrbot_modular_actuators_without_feedback_sensors_for_position_feedback.launch.py
@@ -134,20 +134,21 @@ def generate_launch_description():
         )
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_joint_state_broadcaster_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[robot_controller_spawner],
+            target_action=robot_controller_spawner,
+            on_exit=[joint_state_broadcaster_spawner],
         )
     )
 
     nodes = [
         control_node,
         robot_state_pub_node,
-        joint_state_broadcaster_spawner,
+        robot_controller_spawner,
         delay_rviz_after_joint_state_broadcaster_spawner,
-        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
+        delay_joint_state_broadcaster_after_robot_controller_spawner,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/example_14/hardware/include/ros2_control_demo_example_14/rrbot_actuator_without_feedback.hpp
+++ b/example_14/hardware/include/ros2_control_demo_example_14/rrbot_actuator_without_feedback.hpp
@@ -20,7 +20,6 @@
 #define ROS2_CONTROL_DEMO_EXAMPLE_14__RRBOT_ACTUATOR_WITHOUT_FEEDBACK_HPP_
 
 #include <netinet/in.h>
-#include <sys/socket.h>
 #include <memory>
 #include <string>
 #include <vector>

--- a/example_14/hardware/include/ros2_control_demo_example_14/rrbot_sensor_for_position_feedback.hpp
+++ b/example_14/hardware/include/ros2_control_demo_example_14/rrbot_sensor_for_position_feedback.hpp
@@ -20,7 +20,6 @@
 #define ROS2_CONTROL_DEMO_EXAMPLE_14__RRBOT_SENSOR_FOR_POSITION_FEEDBACK_HPP_
 
 #include <netinet/in.h>
-#include <sys/socket.h>
 #include <memory>
 #include <string>
 #include <thread>

--- a/example_14/hardware/rrbot_actuator_without_feedback.cpp
+++ b/example_14/hardware/rrbot_actuator_without_feedback.cpp
@@ -19,8 +19,10 @@
 #include "ros2_control_demo_example_14/rrbot_actuator_without_feedback.hpp"
 
 #include <netdb.h>
+#include <sys/socket.h>
 #include <chrono>
 #include <cmath>
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <vector>
@@ -94,7 +96,8 @@ hardware_interface::CallbackReturn RRBotActuatorWithoutFeedback::on_init(
   if (connect(sock_, (struct sockaddr *)&address_, sizeof(address_)) < 0)
   {
     RCLCPP_FATAL(
-      rclcpp::get_logger("RRBotActuatorWithoutFeedback"), "Connection over socket failed.");
+      rclcpp::get_logger("RRBotActuatorWithoutFeedback"), "Connection over socket failed: %s",
+      strerror(errno));  // Print the error message
     return hardware_interface::CallbackReturn::ERROR;
   }
   RCLCPP_INFO(rclcpp::get_logger("RRBotActuatorWithoutFeedback"), "Connected to socket");

--- a/example_14/hardware/rrbot_sensor_for_position_feedback.cpp
+++ b/example_14/hardware/rrbot_sensor_for_position_feedback.cpp
@@ -18,10 +18,11 @@
 
 #include "ros2_control_demo_example_14/rrbot_sensor_for_position_feedback.hpp"
 
-#include <netinet/in.h>
+#include <netdb.h>
 #include <sys/socket.h>
 #include <chrono>
 #include <cmath>
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <thread>
@@ -101,7 +102,9 @@ hardware_interface::CallbackReturn RRBotSensorPositionFeedback::on_init(
   RCLCPP_INFO(rclcpp::get_logger("RRBotSensorPositionFeedback"), "Binding to socket address.");
   if (bind(obj_socket_, reinterpret_cast<struct sockaddr *>(&address_), sizeof(address_)) < 0)
   {
-    RCLCPP_FATAL(rclcpp::get_logger("RRBotSensorPositionFeedback"), "Binding to socket failed.");
+    RCLCPP_FATAL(
+      rclcpp::get_logger("RRBotSensorPositionFeedback"), "Binding to socket failed: %s",
+      strerror(errno));  // Print the error message
     return hardware_interface::CallbackReturn::ERROR;
   }
 

--- a/example_14/package.xml
+++ b/example_14/package.xml
@@ -31,11 +31,11 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
+  <test_depend>ros2_control_demo_testing</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/example_14/package.xml
+++ b/example_14/package.xml
@@ -24,6 +24,7 @@
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>ros2_control_demo_description</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>ros2controlcli</exec_depend>
   <exec_depend>ros2launch</exec_depend>

--- a/example_14/package.xml
+++ b/example_14/package.xml
@@ -32,7 +32,6 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>ros2_control_demo_testing</test_depend>

--- a/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
+++ b/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
@@ -95,6 +95,7 @@ class TestFixture(unittest.TestCase):
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# see https://github.com/ros-controls/ros2_control_demos/issues/542
 # @launch_testing.post_shutdown_test()
 # # These tests are run after the processes in generate_test_description() have shutdown.
 # class TestDescriptionCraneShutdown(unittest.TestCase):

--- a/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
+++ b/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import os
+import pytest
+import unittest
+import time
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+
+# import launch_testing.markers
+from launch_testing_ros import WaitForTopics
+from controller_manager.controller_manager_services import list_controllers
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("ros2_control_demo_example_14"),
+                "launch/rrbot_modular_actuators_without_feedback_sensors_for_position_feedback.launch.py",
+            )
+        ),
+        launch_arguments={"gui": "false"}.items(),
+    )
+
+    return LaunchDescription([launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "robot_state_publisher" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "robot_state_publisher not found!"
+
+    def test_controller_running(self, proc_output):
+
+        cname = "forward_velocity_controller"
+
+        start = time.time()
+        found = False
+        while time.time() - start < 10.0 and not found:
+            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                if c.name == cname and c.state == "active":
+                    found = True
+                    break
+        assert found, f"{cname} not found!"
+
+    def test_check_if_msgs_published(self):
+        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 2, "Wrong number of joints in message"
+        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
+        wait_for_topics.shutdown()
+
+
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
+
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
+++ b/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
@@ -40,11 +40,9 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
-from launch_testing_ros import WaitForTopics
-from controller_manager.controller_manager_services import list_controllers
 import rclpy
 from rclpy.node import Node
-from sensor_msgs.msg import JointState
+from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -78,34 +76,22 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         start = time.time()
         found = False
-        while time.time() - start < 2.0 and not found:
+        while time.time() - start < 5.0 and not found:
             found = "robot_state_publisher" in self.node.get_node_names()
             time.sleep(0.1)
         assert found, "robot_state_publisher not found!"
 
     def test_controller_running(self, proc_output):
 
-        cname = "forward_velocity_controller"
+        cnames = [
+            "forward_velocity_controller",
+            "joint_state_broadcaster",
+        ]
 
-        start = time.time()
-        found = False
-        while time.time() - start < 10.0 and not found:
-            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
-            assert controllers, "No controllers found!"
-            for c in controllers:
-                if c.name == cname and c.state == "active":
-                    found = True
-                    break
-        assert found, f"{cname} not found!"
+        check_controllers_running(self.node, cnames)
 
     def test_check_if_msgs_published(self):
-        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
-        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
-        msgs = wait_for_topics.received_messages("/joint_states")
-        msg = msgs[0]
-        assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
-        wait_for_topics.shutdown()
+        check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore

--- a/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
+++ b/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
@@ -31,7 +31,6 @@
 import os
 import pytest
 import unittest
-import time
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -42,7 +41,11 @@ from launch_testing.actions import ReadyToTest
 # import launch_testing.markers
 import rclpy
 from rclpy.node import Node
-from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
+from ros2_control_demo_testing.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -74,12 +77,7 @@ class TestFixture(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running(self, proc_output):
 

--- a/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
+++ b/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
@@ -95,7 +95,6 @@ class TestFixture(unittest.TestCase):
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# see https://github.com/ros-controls/ros2_control_demos/issues/542
 # @launch_testing.post_shutdown_test()
 # # These tests are run after the processes in generate_test_description() have shutdown.
 # class TestDescriptionCraneShutdown(unittest.TestCase):

--- a/example_14/test/test_urdf_xacro.py
+++ b/example_14/test/test_urdf_xacro.py
@@ -39,7 +39,9 @@ from ament_index_python.packages import get_package_share_directory
 def test_urdf_xacro():
     # General Arguments
     description_package = "ros2_control_demo_example_14"
-    description_file = "rrbot.urdf.xacro"
+    description_file = (
+        "rrbot_modular_actuators_without_feedback_sensors_for_position_feedback.urdf.xacro"
+    )
 
     description_file_path = os.path.join(
         get_package_share_directory(description_package), "urdf", description_file

--- a/example_15/CMakeLists.txt
+++ b/example_15/CMakeLists.txt
@@ -26,7 +26,6 @@ install(
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)
 
   ament_add_pytest_test(test_rrbot_namespace_launch test/test_rrbot_namespace_launch.py)

--- a/example_15/CMakeLists.txt
+++ b/example_15/CMakeLists.txt
@@ -28,8 +28,9 @@ install(
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
 
-  ament_add_pytest_test(test_rrbot_namespace_launch test/test_rrbot_namespace_launch.py)
-  ament_add_pytest_test(test_multi_controller_manager_launch test/test_multi_controller_manager_launch.py)
+  # TODO(christophfroehlich) deactivated because of bug in spawner
+  # ament_add_pytest_test(test_rrbot_namespace_launch test/test_rrbot_namespace_launch.py)
+  # ament_add_pytest_test(test_multi_controller_manager_launch test/test_multi_controller_manager_launch.py)
 
 endif()
 

--- a/example_15/bringup/launch/multi_controller_manager_example_two_rrbots.launch.py
+++ b/example_15/bringup/launch/multi_controller_manager_example_two_rrbots.launch.py
@@ -14,6 +14,7 @@
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, ThisLaunchFileDir
 
@@ -51,6 +52,16 @@ def generate_launch_description():
             description="Robot controller to start.",
         )
     )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "start_rviz",
+            default_value="true",
+            description="Start RViz2 automatically with this launch file.",
+        )
+    )
+
+    # Initialize Arguments
+    start_rviz = LaunchConfiguration("start_rviz")
 
     # Initialize Arguments
     use_mock_hardware = LaunchConfiguration("use_mock_hardware")
@@ -126,6 +137,7 @@ def generate_launch_description():
         name="rviz2",
         output="log",
         arguments=["-d", rviz_config_file],
+        condition=IfCondition(start_rviz),
     )
 
     included_launch_files = [

--- a/example_15/bringup/launch/multi_controller_manager_example_two_rrbots.launch.py
+++ b/example_15/bringup/launch/multi_controller_manager_example_two_rrbots.launch.py
@@ -54,14 +54,14 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "start_rviz",
+            "start_rviz_multi",
             default_value="true",
             description="Start RViz2 automatically with this launch file.",
         )
     )
 
     # Initialize Arguments
-    start_rviz = LaunchConfiguration("start_rviz")
+    start_rviz_lc = LaunchConfiguration("start_rviz_multi")
 
     # Initialize Arguments
     use_mock_hardware = LaunchConfiguration("use_mock_hardware")
@@ -131,13 +131,13 @@ def generate_launch_description():
         [FindPackageShare("ros2_control_demo_example_15"), "rviz", "multi_controller_manager.rviz"]
     )
 
-    rviz_node = Node(
+    rviz_node_multi = Node(
         package="rviz2",
         executable="rviz2",
-        name="rviz2",
+        name="rviz2_multi",
         output="log",
         arguments=["-d", rviz_config_file],
-        condition=IfCondition(start_rviz),
+        condition=IfCondition(start_rviz_lc),
     )
 
     included_launch_files = [
@@ -148,7 +148,7 @@ def generate_launch_description():
     nodes_to_start = [
         rrbot_1_position_trajectory_controller_spawner,
         rrbot_2_position_trajectory_controller_spawner,
-        rviz_node,
+        rviz_node_multi,
     ]
 
     return LaunchDescription(declared_arguments + included_launch_files + nodes_to_start)

--- a/example_15/bringup/launch/rrbot_base.launch.py
+++ b/example_15/bringup/launch/rrbot_base.launch.py
@@ -220,12 +220,21 @@ def generate_launch_description():
         )
     )
 
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_joint_state_broadcaster_after_robot_controller_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=robot_controller_spawner,
+            on_exit=[joint_state_broadcaster_spawner],
+        )
+    )
+
     nodes = [
         control_node,
         robot_state_pub_node,
-        joint_state_broadcaster_spawner,
-        delay_rviz_after_joint_state_broadcaster_spawner,
         robot_controller_spawner,
+        delay_joint_state_broadcaster_after_robot_controller_spawner,
+        delay_rviz_after_joint_state_broadcaster_spawner,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/example_15/bringup/launch/rrbot_namespace.launch.py
+++ b/example_15/bringup/launch/rrbot_namespace.launch.py
@@ -14,15 +14,29 @@
 
 
 from launch import LaunchDescription
-from launch.actions import RegisterEventHandler
+from launch.actions import DeclareLaunchArgument, RegisterEventHandler
+from launch.conditions import IfCondition
 from launch.event_handlers import OnProcessExit
-from launch.substitutions import Command, FindExecutable, PathJoinSubstitution
+from launch.substitutions import Command, FindExecutable, LaunchConfiguration, PathJoinSubstitution
 
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
+    # Declare arguments
+    declared_arguments = []
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "start_rviz",
+            default_value="true",
+            description="Start RViz2 automatically with this launch file.",
+        )
+    )
+
+    # Initialize Arguments
+    start_rviz = LaunchConfiguration("start_rviz")
+
     # Get URDF via xacro
     robot_description_content = Command(
         [
@@ -79,6 +93,7 @@ def generate_launch_description():
         name="rviz2",
         output="log",
         arguments=["-d", rviz_config_file],
+        condition=IfCondition(start_rviz),
     )
 
     joint_state_broadcaster_spawner = Node(
@@ -141,4 +156,4 @@ def generate_launch_description():
         delay_robot_position_trajectory_controller_spawner_after_joint_state_broadcaster_spawner,
     ]
 
-    return LaunchDescription(nodes)
+    return LaunchDescription(declared_arguments + nodes)

--- a/example_15/bringup/launch/rrbot_namespace.launch.py
+++ b/example_15/bringup/launch/rrbot_namespace.launch.py
@@ -127,13 +127,12 @@ def generate_launch_description():
         )
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_forward_position_controller_spawner_after_joint_state_broadcaster_spawner = (
-        RegisterEventHandler(
-            event_handler=OnProcessExit(
-                target_action=joint_state_broadcaster_spawner,
-                on_exit=[robot_forward_position_controller_spawner],
-            )
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_joint_state_broadcaster_after_robot_controller_spawner = RegisterEventHandler(
+        event_handler=OnProcessExit(
+            target_action=robot_forward_position_controller_spawner,
+            on_exit=[joint_state_broadcaster_spawner],
         )
     )
 
@@ -150,9 +149,9 @@ def generate_launch_description():
     nodes = [
         control_node,
         robot_state_pub_node,
-        joint_state_broadcaster_spawner,
         delay_rviz_after_joint_state_broadcaster_spawner,
-        delay_robot_forward_position_controller_spawner_after_joint_state_broadcaster_spawner,
+        robot_forward_position_controller_spawner,
+        delay_joint_state_broadcaster_after_robot_controller_spawner,
         delay_robot_position_trajectory_controller_spawner_after_joint_state_broadcaster_spawner,
     ]
 

--- a/example_15/package.xml
+++ b/example_15/package.xml
@@ -29,11 +29,11 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
+  <test_depend>ros2_control_demo_testing</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/example_15/package.xml
+++ b/example_15/package.xml
@@ -30,7 +30,6 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>ros2_control_demo_testing</test_depend>

--- a/example_15/test/test_multi_controller_manager_launch.py
+++ b/example_15/test/test_multi_controller_manager_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-import launch_testing.markers
+# import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 
@@ -96,10 +96,11 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/rrbot_2/joint_states", ["rrbot_2_joint1", "rrbot_2_joint2"])
 
 
-@launch_testing.post_shutdown_test()
-# These tests are run after the processes in generate_test_description() have shutdown.
-class TestDescriptionCraneShutdown(unittest.TestCase):
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
 
-    def test_exit_codes(self, proc_info):
-        """Check if the processes exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info)
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_15/test/test_multi_controller_manager_launch.py
+++ b/example_15/test/test_multi_controller_manager_launch.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 FZI Forschungszentrum Informatik
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
@@ -26,16 +26,25 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 #
-# Author: Lukas Sackewitz
+# Author: Christoph Froehlich
 
 import os
 import pytest
+import unittest
+import time
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
+
+# import launch_testing.markers
+from launch_testing_ros import WaitForTopics
+from controller_manager.controller_manager_services import list_controllers
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -48,7 +57,89 @@ def generate_test_description():
                 "launch/multi_controller_manager_example_two_rrbots.launch.py",
             )
         ),
-        launch_arguments={"gui": "true"}.items(),
+        launch_arguments={"start_rviz": "false"}.items(),
     )
 
     return LaunchDescription([launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "robot_state_publisher" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "robot_state_publisher not found!"
+
+    def test_controller_running_cm1(self, proc_output):
+
+        cname = "forward_position_controller"
+
+        start = time.time()
+        found = False
+        while time.time() - start < 10.0 and not found:
+            controllers = list_controllers(
+                self.node, "/rrbot_1/controller_manager", 5.0
+            ).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                if c.name == cname and c.state == "active":
+                    found = True
+                    break
+        assert found, f"{cname} not found!"
+
+    def test_controller_running_cm2(self, proc_output):
+
+        cname = "forward_position_controller"
+        start = time.time()
+        found = False
+        while time.time() - start < 10.0 and not found:
+            controllers = list_controllers(
+                self.node, "/rrbot_2/controller_manager", 5.0
+            ).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                if c.name == cname and c.state == "active":
+                    found = True
+                    break
+        assert found, f"{cname} not found!"
+
+    def test_check_if_msgs_published_cm1(self):
+        wait_for_topics = WaitForTopics([("/rrbot_1/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/rrbot_1/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/rrbot_1/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 2, "Wrong number of joints in message"
+        assert msg.name == ["rrbot_1_joint1", "rrbot_1_joint2"], "Wrong joint names"
+        wait_for_topics.shutdown()
+
+    def test_check_if_msgs_published_cm2(self):
+        wait_for_topics = WaitForTopics([("/rrbot_2/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/rrbot_2/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/rrbot_2/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 2, "Wrong number of joints in message"
+        assert msg.name == ["rrbot_2_joint1", "rrbot_2_joint2"], "Wrong joint names"
+        wait_for_topics.shutdown()
+
+
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
+
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_15/test/test_multi_controller_manager_launch.py
+++ b/example_15/test/test_multi_controller_manager_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 
@@ -96,11 +96,10 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/rrbot_2/joint_states", ["rrbot_2_joint1", "rrbot_2_joint2"])
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_15/test/test_multi_controller_manager_launch.py
+++ b/example_15/test/test_multi_controller_manager_launch.py
@@ -31,7 +31,6 @@
 import os
 import pytest
 import unittest
-import time
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -42,8 +41,11 @@ from launch_testing.actions import ReadyToTest
 # import launch_testing.markers
 import rclpy
 from rclpy.node import Node
-
-from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
+from ros2_control_demo_testing.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -75,12 +77,7 @@ class TestFixture(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running_cm1(self, proc_output):
 

--- a/example_15/test/test_rrbot_namespace_launch.py
+++ b/example_15/test/test_rrbot_namespace_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-import launch_testing.markers
+# import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 
@@ -95,10 +95,11 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/rrbot/joint_states", ["joint1", "joint2"])
 
 
-@launch_testing.post_shutdown_test()
-# These tests are run after the processes in generate_test_description() have shutdown.
-class TestDescriptionCraneShutdown(unittest.TestCase):
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
 
-    def test_exit_codes(self, proc_info):
-        """Check if the processes exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info)
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_15/test/test_rrbot_namespace_launch.py
+++ b/example_15/test/test_rrbot_namespace_launch.py
@@ -40,11 +40,10 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
-from launch_testing_ros import WaitForTopics
-from controller_manager.controller_manager_services import list_controllers
 import rclpy
 from rclpy.node import Node
-from sensor_msgs.msg import JointState
+
+from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -78,34 +77,22 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         start = time.time()
         found = False
-        while time.time() - start < 2.0 and not found:
+        while time.time() - start < 5.0 and not found:
             found = "robot_state_publisher" in self.node.get_node_names()
             time.sleep(0.1)
         assert found, "robot_state_publisher not found!"
 
     def test_controller_running(self, proc_output):
 
-        cname = "forward_position_controller"
+        cnames = [
+            "forward_position_controller",
+            "joint_state_broadcaster",
+        ]
 
-        start = time.time()
-        found = False
-        while time.time() - start < 10.0 and not found:
-            controllers = list_controllers(self.node, "/rrbot/controller_manager", 5.0).controller
-            assert controllers, "No controllers found!"
-            for c in controllers:
-                if c.name == cname and c.state == "active":
-                    found = True
-                    break
-        assert found, f"{cname} not found!"
+        check_controllers_running(self.node, cnames, "/rrbot")
 
     def test_check_if_msgs_published(self):
-        wait_for_topics = WaitForTopics([("/rrbot/joint_states", JointState)], timeout=15.0)
-        assert wait_for_topics.wait(), "Topic '/rrbot/joint_states' not found!"
-        msgs = wait_for_topics.received_messages("/rrbot/joint_states")
-        msg = msgs[0]
-        assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert msg.name == ["joint1", "joint2"], "Wrong joint names"
-        wait_for_topics.shutdown()
+        check_if_js_published("/rrbot/joint_states", ["joint1", "joint2"])
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore

--- a/example_15/test/test_rrbot_namespace_launch.py
+++ b/example_15/test/test_rrbot_namespace_launch.py
@@ -31,7 +31,6 @@
 import os
 import pytest
 import unittest
-import time
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -42,8 +41,11 @@ from launch_testing.actions import ReadyToTest
 # import launch_testing.markers
 import rclpy
 from rclpy.node import Node
-
-from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
+from ros2_control_demo_testing.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -75,12 +77,7 @@ class TestFixture(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running(self, proc_output):
 

--- a/example_15/test/test_rrbot_namespace_launch.py
+++ b/example_15/test/test_rrbot_namespace_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 
@@ -95,11 +95,10 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/rrbot/joint_states", ["joint1", "joint2"])
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_2/CMakeLists.txt
+++ b/example_2/CMakeLists.txt
@@ -17,6 +17,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # find dependencies
+find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/example_2/CMakeLists.txt
+++ b/example_2/CMakeLists.txt
@@ -66,6 +66,7 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(example_2_urdf_xacro test/test_urdf_xacro.py)
   ament_add_pytest_test(view_example_2_launch test/test_view_robot_launch.py)
+  ament_add_pytest_test(run_example_2_launch test/test_diffbot_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_2/bringup/launch/diffbot.launch.py
+++ b/example_2/bringup/launch/diffbot.launch.py
@@ -114,20 +114,21 @@ def generate_launch_description():
         )
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_joint_state_broadcaster_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[robot_controller_spawner],
+            target_action=robot_controller_spawner,
+            on_exit=[joint_state_broadcaster_spawner],
         )
     )
 
     nodes = [
         control_node,
         robot_state_pub_node,
-        joint_state_broadcaster_spawner,
+        robot_controller_spawner,
         delay_rviz_after_joint_state_broadcaster_spawner,
-        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
+        delay_joint_state_broadcaster_after_robot_controller_spawner,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/example_2/package.xml
+++ b/example_2/package.xml
@@ -33,7 +33,6 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>ros2_control_demo_testing</test_depend>

--- a/example_2/package.xml
+++ b/example_2/package.xml
@@ -15,6 +15,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/example_2/package.xml
+++ b/example_2/package.xml
@@ -32,11 +32,11 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
+  <test_depend>ros2_control_demo_testing</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/example_2/test/test_diffbot_launch.py
+++ b/example_2/test/test_diffbot_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-import launch_testing.markers
+# import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,10 +91,11 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["left_wheel_joint", "right_wheel_joint"])
 
 
-@launch_testing.post_shutdown_test()
-# These tests are run after the processes in generate_test_description() have shutdown.
-class TestDescriptionCraneShutdown(unittest.TestCase):
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
 
-    def test_exit_codes(self, proc_info):
-        """Check if the processes exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info)
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_2/test/test_diffbot_launch.py
+++ b/example_2/test/test_diffbot_launch.py
@@ -40,11 +40,9 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
-from launch_testing_ros import WaitForTopics
-from controller_manager.controller_manager_services import list_controllers
 import rclpy
 from rclpy.node import Node
-from sensor_msgs.msg import JointState
+from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -78,34 +76,19 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         start = time.time()
         found = False
-        while time.time() - start < 2.0 and not found:
+        while time.time() - start < 5.0 and not found:
             found = "robot_state_publisher" in self.node.get_node_names()
             time.sleep(0.1)
         assert found, "robot_state_publisher not found!"
 
     def test_controller_running(self, proc_output):
 
-        cname = "diffbot_base_controller"
+        cnames = ["diffbot_base_controller", "joint_state_broadcaster"]
 
-        start = time.time()
-        found = False
-        while time.time() - start < 10.0 and not found:
-            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
-            assert controllers, "No controllers found!"
-            for c in controllers:
-                if c.name == cname and c.state == "active":
-                    found = True
-                    break
-        assert found, f"{cname} not found!"
+        check_controllers_running(self.node, cnames)
 
     def test_check_if_msgs_published(self):
-        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
-        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
-        msgs = wait_for_topics.received_messages("/joint_states")
-        msg = msgs[0]
-        assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert set(msg.name) == {"left_wheel_joint", "right_wheel_joint"}, "Wrong joint names"
-        wait_for_topics.shutdown()
+        check_if_js_published("/joint_states", ["left_wheel_joint", "right_wheel_joint"])
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore

--- a/example_2/test/test_diffbot_launch.py
+++ b/example_2/test/test_diffbot_launch.py
@@ -104,7 +104,7 @@ class TestFixture(unittest.TestCase):
         msgs = wait_for_topics.received_messages("/joint_states")
         msg = msgs[0]
         assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert msg.name == ["left_wheel_joint", "right_wheel_joint"], "Wrong joint names"
+        assert set(msg.name) == {"left_wheel_joint", "right_wheel_joint"}, "Wrong joint names"
         wait_for_topics.shutdown()
 
 

--- a/example_2/test/test_diffbot_launch.py
+++ b/example_2/test/test_diffbot_launch.py
@@ -31,7 +31,6 @@
 import os
 import pytest
 import unittest
-import time
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -42,7 +41,11 @@ from launch_testing.actions import ReadyToTest
 # import launch_testing.markers
 import rclpy
 from rclpy.node import Node
-from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
+from ros2_control_demo_testing.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -74,12 +77,7 @@ class TestFixture(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running(self, proc_output):
 

--- a/example_2/test/test_diffbot_launch.py
+++ b/example_2/test/test_diffbot_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,11 +91,10 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["left_wheel_joint", "right_wheel_joint"])
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_2/test/test_diffbot_launch.py
+++ b/example_2/test/test_diffbot_launch.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import os
+import pytest
+import unittest
+import time
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+
+# import launch_testing.markers
+from launch_testing_ros import WaitForTopics
+from controller_manager.controller_manager_services import list_controllers
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("ros2_control_demo_example_2"),
+                "launch/diffbot.launch.py",
+            )
+        ),
+        launch_arguments={"gui": "true"}.items(),
+    )
+
+    return LaunchDescription([launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "robot_state_publisher" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "robot_state_publisher not found!"
+
+    def test_controller_running(self, proc_output):
+
+        cname = "diffbot_base_controller"
+
+        start = time.time()
+        found = False
+        while time.time() - start < 10.0 and not found:
+            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                if c.name == cname and c.state == "active":
+                    found = True
+                    break
+        assert found, f"{cname} not found!"
+
+    def test_check_if_msgs_published(self):
+        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 2, "Wrong number of joints in message"
+        assert msg.name == ["left_wheel_joint", "right_wheel_joint"], "Wrong joint names"
+        wait_for_topics.shutdown()
+
+
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
+
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_2/test/test_diffbot_launch.py
+++ b/example_2/test/test_diffbot_launch.py
@@ -57,7 +57,7 @@ def generate_test_description():
                 "launch/diffbot.launch.py",
             )
         ),
-        launch_arguments={"gui": "true"}.items(),
+        launch_arguments={"gui": "False"}.items(),
     )
 
     return LaunchDescription([launch_include, ReadyToTest()])

--- a/example_3/CMakeLists.txt
+++ b/example_3/CMakeLists.txt
@@ -17,6 +17,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # find dependencies
+find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/example_3/CMakeLists.txt
+++ b/example_3/CMakeLists.txt
@@ -66,6 +66,7 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(example_3_urdf_xacro test/test_urdf_xacro.py)
   ament_add_pytest_test(view_example_3_launch test/test_view_robot_launch.py)
+  ament_add_pytest_test(run_example_3_launch test/test_rrbot_system_multi_interface_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_3/bringup/config/rrbot_multi_interface_forward_controllers.yaml
+++ b/example_3/bringup/config/rrbot_multi_interface_forward_controllers.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 100  # Hz
+    update_rate: 10  # Hz
 
     forward_position_controller:
       type: position_controllers/JointGroupPositionController

--- a/example_3/bringup/launch/rrbot_system_multi_interface.launch.py
+++ b/example_3/bringup/launch/rrbot_system_multi_interface.launch.py
@@ -157,20 +157,21 @@ def generate_launch_description():
         )
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_joint_state_broadcaster_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[robot_controller_spawner],
+            target_action=robot_controller_spawner,
+            on_exit=[joint_state_broadcaster_spawner],
         )
     )
 
     nodes = [
         control_node,
         robot_state_pub_node,
-        joint_state_broadcaster_spawner,
+        robot_controller_spawner,
         delay_rviz_after_joint_state_broadcaster_spawner,
-        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
+        delay_joint_state_broadcaster_after_robot_controller_spawner,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/example_3/package.xml
+++ b/example_3/package.xml
@@ -33,7 +33,6 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>ros2_control_demo_testing</test_depend>

--- a/example_3/package.xml
+++ b/example_3/package.xml
@@ -32,11 +32,11 @@
   <exec_depend>velocity_controllers</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
+  <test_depend>ros2_control_demo_testing</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/example_3/package.xml
+++ b/example_3/package.xml
@@ -22,12 +22,14 @@
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
+  <exec_depend>position_controllers</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ros2_control_demo_description</exec_depend>
   <exec_depend>ros2_controllers_test_nodes</exec_depend>
   <exec_depend>ros2controlcli</exec_depend>
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>rviz2</exec_depend>
+  <exec_depend>velocity_controllers</exec_depend>
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/example_3/package.xml
+++ b/example_3/package.xml
@@ -13,6 +13,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/example_3/test/test_rrbot_system_multi_interface_launch.py
+++ b/example_3/test/test_rrbot_system_multi_interface_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,11 +91,10 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_3/test/test_rrbot_system_multi_interface_launch.py
+++ b/example_3/test/test_rrbot_system_multi_interface_launch.py
@@ -40,11 +40,9 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
-from launch_testing_ros import WaitForTopics
-from controller_manager.controller_manager_services import list_controllers
 import rclpy
 from rclpy.node import Node
-from sensor_msgs.msg import JointState
+from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -78,34 +76,19 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         start = time.time()
         found = False
-        while time.time() - start < 2.0 and not found:
+        while time.time() - start < 5.0 and not found:
             found = "robot_state_publisher" in self.node.get_node_names()
             time.sleep(0.1)
         assert found, "robot_state_publisher not found!"
 
     def test_controller_running(self, proc_output):
 
-        cname = "forward_velocity_controller"
+        cnames = ["forward_velocity_controller", "joint_state_broadcaster"]
 
-        start = time.time()
-        found = False
-        while time.time() - start < 10.0 and not found:
-            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
-            assert controllers, "No controllers found!"
-            for c in controllers:
-                if c.name == cname and c.state == "active":
-                    found = True
-                    break
-        assert found, f"{cname} not found!"
+        check_controllers_running(self.node, cnames)
 
     def test_check_if_msgs_published(self):
-        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
-        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
-        msgs = wait_for_topics.received_messages("/joint_states")
-        msg = msgs[0]
-        assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
-        wait_for_topics.shutdown()
+        check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore

--- a/example_3/test/test_rrbot_system_multi_interface_launch.py
+++ b/example_3/test/test_rrbot_system_multi_interface_launch.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import os
+import pytest
+import unittest
+import time
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+
+# import launch_testing.markers
+from launch_testing_ros import WaitForTopics
+from controller_manager.controller_manager_services import list_controllers
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("ros2_control_demo_example_3"),
+                "launch/rrbot_system_multi_interface.launch.py",
+            )
+        ),
+        launch_arguments={"gui": "true"}.items(),
+    )
+
+    return LaunchDescription([launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "robot_state_publisher" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "robot_state_publisher not found!"
+
+    def test_controller_running(self, proc_output):
+
+        cname = "forward_velocity_controller"
+
+        start = time.time()
+        found = False
+        while time.time() - start < 10.0 and not found:
+            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                if c.name == cname and c.state == "active":
+                    found = True
+                    break
+        assert found, f"{cname} not found!"
+
+    def test_check_if_msgs_published(self):
+        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 2, "Wrong number of joints in message"
+        assert msg.name == ["joint1", "joint2"], "Wrong joint names"
+        wait_for_topics.shutdown()
+
+
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
+
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_3/test/test_rrbot_system_multi_interface_launch.py
+++ b/example_3/test/test_rrbot_system_multi_interface_launch.py
@@ -104,7 +104,7 @@ class TestFixture(unittest.TestCase):
         msgs = wait_for_topics.received_messages("/joint_states")
         msg = msgs[0]
         assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert msg.name == ["joint1", "joint2"], "Wrong joint names"
+        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
         wait_for_topics.shutdown()
 
 

--- a/example_3/test/test_rrbot_system_multi_interface_launch.py
+++ b/example_3/test/test_rrbot_system_multi_interface_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-import launch_testing.markers
+# import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,10 +91,11 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-@launch_testing.post_shutdown_test()
-# These tests are run after the processes in generate_test_description() have shutdown.
-class TestDescriptionCraneShutdown(unittest.TestCase):
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
 
-    def test_exit_codes(self, proc_info):
-        """Check if the processes exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info)
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_3/test/test_rrbot_system_multi_interface_launch.py
+++ b/example_3/test/test_rrbot_system_multi_interface_launch.py
@@ -57,7 +57,7 @@ def generate_test_description():
                 "launch/rrbot_system_multi_interface.launch.py",
             )
         ),
-        launch_arguments={"gui": "true"}.items(),
+        launch_arguments={"gui": "False"}.items(),
     )
 
     return LaunchDescription([launch_include, ReadyToTest()])

--- a/example_3/test/test_rrbot_system_multi_interface_launch.py
+++ b/example_3/test/test_rrbot_system_multi_interface_launch.py
@@ -31,7 +31,6 @@
 import os
 import pytest
 import unittest
-import time
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -42,7 +41,11 @@ from launch_testing.actions import ReadyToTest
 # import launch_testing.markers
 import rclpy
 from rclpy.node import Node
-from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
+from ros2_control_demo_testing.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -74,12 +77,7 @@ class TestFixture(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running(self, proc_output):
 

--- a/example_4/CMakeLists.txt
+++ b/example_4/CMakeLists.txt
@@ -17,6 +17,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # find dependencies
+find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/example_4/CMakeLists.txt
+++ b/example_4/CMakeLists.txt
@@ -66,6 +66,7 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(example_4_urdf_xacro test/test_urdf_xacro.py)
   ament_add_pytest_test(view_example_4_launch test/test_view_robot_launch.py)
+  ament_add_pytest_test(run_example_4_launch test/test_rrbot_system_with_sensor_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_4/bringup/config/rrbot_with_sensor_controllers.yaml
+++ b/example_4/bringup/config/rrbot_with_sensor_controllers.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 100  # Hz
+    update_rate: 10  # Hz
 
     forward_position_controller:
       type: forward_command_controller/ForwardCommandController

--- a/example_4/bringup/launch/rrbot_system_with_sensor.launch.py
+++ b/example_4/bringup/launch/rrbot_system_with_sensor.launch.py
@@ -156,20 +156,21 @@ def generate_launch_description():
         )
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_joint_state_broadcaster_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[robot_controller_spawner],
+            target_action=robot_controller_spawner,
+            on_exit=[joint_state_broadcaster_spawner],
         )
     )
 
     nodes = [
         control_node,
         robot_state_pub_node,
-        joint_state_broadcaster_spawner,
+        robot_controller_spawner,
         delay_rviz_after_joint_state_broadcaster_spawner,
-        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
+        delay_joint_state_broadcaster_after_robot_controller_spawner,
         fts_broadcaster_spawner,
     ]
 

--- a/example_4/package.xml
+++ b/example_4/package.xml
@@ -31,11 +31,11 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
+  <test_depend>ros2_control_demo_testing</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/example_4/package.xml
+++ b/example_4/package.xml
@@ -19,6 +19,7 @@
   <depend>rclcpp_lifecycle</depend>
 
   <exec_depend>controller_manager</exec_depend>
+  <exec_depend>force_torque_sensor_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>

--- a/example_4/package.xml
+++ b/example_4/package.xml
@@ -13,6 +13,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/example_4/package.xml
+++ b/example_4/package.xml
@@ -32,7 +32,6 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>ros2_control_demo_testing</test_depend>

--- a/example_4/test/test_rrbot_system_with_sensor_launch.py
+++ b/example_4/test/test_rrbot_system_with_sensor_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,11 +91,10 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_4/test/test_rrbot_system_with_sensor_launch.py
+++ b/example_4/test/test_rrbot_system_with_sensor_launch.py
@@ -104,7 +104,7 @@ class TestFixture(unittest.TestCase):
         msgs = wait_for_topics.received_messages("/joint_states")
         msg = msgs[0]
         assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert msg.name == ["joint1", "joint2"], "Wrong joint names"
+        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
         wait_for_topics.shutdown()
 
 

--- a/example_4/test/test_rrbot_system_with_sensor_launch.py
+++ b/example_4/test/test_rrbot_system_with_sensor_launch.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import os
+import pytest
+import unittest
+import time
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+
+# import launch_testing.markers
+from launch_testing_ros import WaitForTopics
+from controller_manager.controller_manager_services import list_controllers
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("ros2_control_demo_example_4"),
+                "launch/rrbot_system_with_sensor.launch.py",
+            )
+        ),
+        launch_arguments={"gui": "true"}.items(),
+    )
+
+    return LaunchDescription([launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "robot_state_publisher" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "robot_state_publisher not found!"
+
+    def test_controller_running(self, proc_output):
+
+        cname = "forward_position_controller"
+
+        start = time.time()
+        found = False
+        while time.time() - start < 10.0 and not found:
+            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                if c.name == cname and c.state == "active":
+                    found = True
+                    break
+        assert found, f"{cname} not found!"
+
+    def test_check_if_msgs_published(self):
+        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 2, "Wrong number of joints in message"
+        assert msg.name == ["joint1", "joint2"], "Wrong joint names"
+        wait_for_topics.shutdown()
+
+
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
+
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_4/test/test_rrbot_system_with_sensor_launch.py
+++ b/example_4/test/test_rrbot_system_with_sensor_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-import launch_testing.markers
+# import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,10 +91,11 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-@launch_testing.post_shutdown_test()
-# These tests are run after the processes in generate_test_description() have shutdown.
-class TestDescriptionCraneShutdown(unittest.TestCase):
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
 
-    def test_exit_codes(self, proc_info):
-        """Check if the processes exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info)
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_4/test/test_rrbot_system_with_sensor_launch.py
+++ b/example_4/test/test_rrbot_system_with_sensor_launch.py
@@ -31,7 +31,6 @@
 import os
 import pytest
 import unittest
-import time
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -42,7 +41,11 @@ from launch_testing.actions import ReadyToTest
 # import launch_testing.markers
 import rclpy
 from rclpy.node import Node
-from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
+from ros2_control_demo_testing.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -74,12 +77,7 @@ class TestFixture(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running(self, proc_output):
 

--- a/example_4/test/test_rrbot_system_with_sensor_launch.py
+++ b/example_4/test/test_rrbot_system_with_sensor_launch.py
@@ -57,7 +57,7 @@ def generate_test_description():
                 "launch/rrbot_system_with_sensor.launch.py",
             )
         ),
-        launch_arguments={"gui": "true"}.items(),
+        launch_arguments={"gui": "False"}.items(),
     )
 
     return LaunchDescription([launch_include, ReadyToTest()])

--- a/example_4/test/test_rrbot_system_with_sensor_launch.py
+++ b/example_4/test/test_rrbot_system_with_sensor_launch.py
@@ -40,11 +40,9 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
-from launch_testing_ros import WaitForTopics
-from controller_manager.controller_manager_services import list_controllers
 import rclpy
 from rclpy.node import Node
-from sensor_msgs.msg import JointState
+from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -78,34 +76,19 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         start = time.time()
         found = False
-        while time.time() - start < 2.0 and not found:
+        while time.time() - start < 5.0 and not found:
             found = "robot_state_publisher" in self.node.get_node_names()
             time.sleep(0.1)
         assert found, "robot_state_publisher not found!"
 
     def test_controller_running(self, proc_output):
 
-        cname = "forward_position_controller"
+        cnames = ["forward_position_controller", "fts_broadcaster", "joint_state_broadcaster"]
 
-        start = time.time()
-        found = False
-        while time.time() - start < 10.0 and not found:
-            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
-            assert controllers, "No controllers found!"
-            for c in controllers:
-                if c.name == cname and c.state == "active":
-                    found = True
-                    break
-        assert found, f"{cname} not found!"
+        check_controllers_running(self.node, cnames)
 
     def test_check_if_msgs_published(self):
-        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
-        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
-        msgs = wait_for_topics.received_messages("/joint_states")
-        msg = msgs[0]
-        assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
-        wait_for_topics.shutdown()
+        check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore

--- a/example_5/CMakeLists.txt
+++ b/example_5/CMakeLists.txt
@@ -17,6 +17,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # find dependencies
+find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/example_5/CMakeLists.txt
+++ b/example_5/CMakeLists.txt
@@ -67,6 +67,7 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(example_5_urdf_xacro test/test_urdf_xacro.py)
   ament_add_pytest_test(view_example_5_launch test/test_view_robot_launch.py)
+  ament_add_pytest_test(run_example_5_launch test/test_rrbot_system_with_external_sensor_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_5/bringup/config/rrbot_with_external_sensor_controllers.yaml
+++ b/example_5/bringup/config/rrbot_with_external_sensor_controllers.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 100  # Hz
+    update_rate: 10  # Hz
 
     forward_position_controller:
       type: forward_command_controller/ForwardCommandController

--- a/example_5/bringup/launch/rrbot_system_with_external_sensor.launch.py
+++ b/example_5/bringup/launch/rrbot_system_with_external_sensor.launch.py
@@ -156,20 +156,21 @@ def generate_launch_description():
         )
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_joint_state_broadcaster_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[robot_controller_spawner],
+            target_action=robot_controller_spawner,
+            on_exit=[joint_state_broadcaster_spawner],
         )
     )
 
     nodes = [
         control_node,
         robot_state_pub_node,
-        joint_state_broadcaster_spawner,
+        robot_controller_spawner,
         delay_rviz_after_joint_state_broadcaster_spawner,
-        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
+        delay_joint_state_broadcaster_after_robot_controller_spawner,
         fts_broadcaster_spawner,
     ]
 

--- a/example_5/package.xml
+++ b/example_5/package.xml
@@ -31,11 +31,11 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
+  <test_depend>ros2_control_demo_testing</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/example_5/package.xml
+++ b/example_5/package.xml
@@ -19,6 +19,7 @@
   <depend>rclcpp_lifecycle</depend>
 
   <exec_depend>controller_manager</exec_depend>
+  <exec_depend>force_torque_sensor_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>

--- a/example_5/package.xml
+++ b/example_5/package.xml
@@ -13,6 +13,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/example_5/package.xml
+++ b/example_5/package.xml
@@ -32,7 +32,6 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>ros2_control_demo_testing</test_depend>

--- a/example_5/test/test_rrbot_system_with_external_sensor_launch.py
+++ b/example_5/test/test_rrbot_system_with_external_sensor_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,11 +91,10 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_5/test/test_rrbot_system_with_external_sensor_launch.py
+++ b/example_5/test/test_rrbot_system_with_external_sensor_launch.py
@@ -108,7 +108,7 @@ class TestFixture(unittest.TestCase):
         msgs = wait_for_topics.received_messages("/joint_states")
         msg = msgs[0]
         assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert msg.name == ["joint1", "joint2"], "Wrong joint names"
+        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
         wait_for_topics.shutdown()
 
 

--- a/example_5/test/test_rrbot_system_with_external_sensor_launch.py
+++ b/example_5/test/test_rrbot_system_with_external_sensor_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-import launch_testing.markers
+# import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,10 +91,11 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-@launch_testing.post_shutdown_test()
-# These tests are run after the processes in generate_test_description() have shutdown.
-class TestDescriptionCraneShutdown(unittest.TestCase):
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
 
-    def test_exit_codes(self, proc_info):
-        """Check if the processes exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info)
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_5/test/test_rrbot_system_with_external_sensor_launch.py
+++ b/example_5/test/test_rrbot_system_with_external_sensor_launch.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import os
+import pytest
+import unittest
+import time
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+
+# import launch_testing.markers
+from launch_testing_ros import WaitForTopics
+from controller_manager.controller_manager_services import list_controllers
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("ros2_control_demo_example_5"),
+                "launch/rrbot_system_with_external_sensor.launch.py",
+            )
+        ),
+        launch_arguments={"gui": "false"}.items(),
+    )
+
+    return LaunchDescription([launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "robot_state_publisher" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "robot_state_publisher not found!"
+
+    def test_controller_running(self, proc_output):
+
+        cnames = ["forward_position_controller", "fts_broadcaster", "joint_state_broadcaster"]
+        found = {cname: False for cname in cnames}  # Define 'found' as a dictionary
+
+        start = time.time()
+        while time.time() - start < 10.0 and not all(found.values()):
+            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                for cname in cnames:
+                    if c.name == cname and c.state == "active":
+                        found[cname] = True
+                        break
+
+        assert all(
+            found.values()
+        ), f"Controller(s) not found: {', '.join([cname for cname, is_found in found.items() if not is_found])}"
+
+    def test_check_if_msgs_published(self):
+        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 2, "Wrong number of joints in message"
+        assert msg.name == ["joint1", "joint2"], "Wrong joint names"
+        wait_for_topics.shutdown()
+
+
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
+
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_5/test/test_rrbot_system_with_external_sensor_launch.py
+++ b/example_5/test/test_rrbot_system_with_external_sensor_launch.py
@@ -40,11 +40,9 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
-from launch_testing_ros import WaitForTopics
-from controller_manager.controller_manager_services import list_controllers
 import rclpy
 from rclpy.node import Node
-from sensor_msgs.msg import JointState
+from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -78,7 +76,7 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         start = time.time()
         found = False
-        while time.time() - start < 2.0 and not found:
+        while time.time() - start < 5.0 and not found:
             found = "robot_state_publisher" in self.node.get_node_names()
             time.sleep(0.1)
         assert found, "robot_state_publisher not found!"
@@ -86,30 +84,11 @@ class TestFixture(unittest.TestCase):
     def test_controller_running(self, proc_output):
 
         cnames = ["forward_position_controller", "fts_broadcaster", "joint_state_broadcaster"]
-        found = {cname: False for cname in cnames}  # Define 'found' as a dictionary
 
-        start = time.time()
-        while time.time() - start < 10.0 and not all(found.values()):
-            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
-            assert controllers, "No controllers found!"
-            for c in controllers:
-                for cname in cnames:
-                    if c.name == cname and c.state == "active":
-                        found[cname] = True
-                        break
-
-        assert all(
-            found.values()
-        ), f"Controller(s) not found: {', '.join([cname for cname, is_found in found.items() if not is_found])}"
+        check_controllers_running(self.node, cnames)
 
     def test_check_if_msgs_published(self):
-        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
-        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
-        msgs = wait_for_topics.received_messages("/joint_states")
-        msg = msgs[0]
-        assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
-        wait_for_topics.shutdown()
+        check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore

--- a/example_5/test/test_rrbot_system_with_external_sensor_launch.py
+++ b/example_5/test/test_rrbot_system_with_external_sensor_launch.py
@@ -31,7 +31,6 @@
 import os
 import pytest
 import unittest
-import time
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -42,7 +41,11 @@ from launch_testing.actions import ReadyToTest
 # import launch_testing.markers
 import rclpy
 from rclpy.node import Node
-from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
+from ros2_control_demo_testing.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -74,12 +77,7 @@ class TestFixture(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running(self, proc_output):
 

--- a/example_6/CMakeLists.txt
+++ b/example_6/CMakeLists.txt
@@ -17,6 +17,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # find dependencies
+find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/example_6/CMakeLists.txt
+++ b/example_6/CMakeLists.txt
@@ -66,6 +66,7 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(example_6_urdf_xacro test/test_urdf_xacro.py)
   ament_add_pytest_test(view_example_6_launch test/test_view_robot_launch.py)
+  ament_add_pytest_test(run_example_6_launch test/test_rrbot_modular_actuators_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_6/bringup/config/rrbot_modular_actuators.yaml
+++ b/example_6/bringup/config/rrbot_modular_actuators.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 100  # Hz
+    update_rate: 10  # Hz
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster

--- a/example_6/bringup/launch/rrbot_modular_actuators.launch.py
+++ b/example_6/bringup/launch/rrbot_modular_actuators.launch.py
@@ -157,20 +157,21 @@ def generate_launch_description():
         )
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_joint_state_broadcaster_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[robot_controller_spawner],
+            target_action=robot_controller_spawner,
+            on_exit=[joint_state_broadcaster_spawner],
         )
     )
 
     nodes = [
         control_node,
         robot_state_pub_node,
-        joint_state_broadcaster_spawner,
+        robot_controller_spawner,
         delay_rviz_after_joint_state_broadcaster_spawner,
-        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
+        delay_joint_state_broadcaster_after_robot_controller_spawner,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/example_6/package.xml
+++ b/example_6/package.xml
@@ -31,7 +31,6 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>ros2_control_demo_testing</test_depend>

--- a/example_6/package.xml
+++ b/example_6/package.xml
@@ -13,6 +13,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/example_6/package.xml
+++ b/example_6/package.xml
@@ -30,11 +30,11 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
+  <test_depend>ros2_control_demo_testing</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/example_6/test/test_rrbot_modular_actuators_launch.py
+++ b/example_6/test/test_rrbot_modular_actuators_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,11 +91,10 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_6/test/test_rrbot_modular_actuators_launch.py
+++ b/example_6/test/test_rrbot_modular_actuators_launch.py
@@ -40,11 +40,9 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
-from launch_testing_ros import WaitForTopics
-from controller_manager.controller_manager_services import list_controllers
 import rclpy
 from rclpy.node import Node
-from sensor_msgs.msg import JointState
+from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -78,34 +76,19 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         start = time.time()
         found = False
-        while time.time() - start < 2.0 and not found:
+        while time.time() - start < 5.0 and not found:
             found = "robot_state_publisher" in self.node.get_node_names()
             time.sleep(0.1)
         assert found, "robot_state_publisher not found!"
 
     def test_controller_running(self, proc_output):
 
-        cname = "forward_position_controller"
+        cnames = ["forward_position_controller", "joint_state_broadcaster"]
 
-        start = time.time()
-        found = False
-        while time.time() - start < 10.0 and not found:
-            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
-            assert controllers, "No controllers found!"
-            for c in controllers:
-                if c.name == cname and c.state == "active":
-                    found = True
-                    break
-        assert found, f"{cname} not found!"
+        check_controllers_running(self.node, cnames)
 
     def test_check_if_msgs_published(self):
-        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
-        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
-        msgs = wait_for_topics.received_messages("/joint_states")
-        msg = msgs[0]
-        assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
-        wait_for_topics.shutdown()
+        check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore

--- a/example_6/test/test_rrbot_modular_actuators_launch.py
+++ b/example_6/test/test_rrbot_modular_actuators_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-import launch_testing.markers
+# import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,10 +91,11 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-@launch_testing.post_shutdown_test()
-# These tests are run after the processes in generate_test_description() have shutdown.
-class TestDescriptionCraneShutdown(unittest.TestCase):
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
 
-    def test_exit_codes(self, proc_info):
-        """Check if the processes exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info)
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_6/test/test_rrbot_modular_actuators_launch.py
+++ b/example_6/test/test_rrbot_modular_actuators_launch.py
@@ -31,7 +31,6 @@
 import os
 import pytest
 import unittest
-import time
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -42,7 +41,11 @@ from launch_testing.actions import ReadyToTest
 # import launch_testing.markers
 import rclpy
 from rclpy.node import Node
-from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
+from ros2_control_demo_testing.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -74,12 +77,7 @@ class TestFixture(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running(self, proc_output):
 

--- a/example_6/test/test_rrbot_modular_actuators_launch.py
+++ b/example_6/test/test_rrbot_modular_actuators_launch.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import os
+import pytest
+import unittest
+import time
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+
+# import launch_testing.markers
+from launch_testing_ros import WaitForTopics
+from controller_manager.controller_manager_services import list_controllers
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("ros2_control_demo_example_6"),
+                "launch/rrbot_modular_actuators.launch.py",
+            )
+        ),
+        launch_arguments={"gui": "false"}.items(),
+    )
+
+    return LaunchDescription([launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "robot_state_publisher" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "robot_state_publisher not found!"
+
+    def test_controller_running(self, proc_output):
+
+        cname = "forward_position_controller"
+
+        start = time.time()
+        found = False
+        while time.time() - start < 10.0 and not found:
+            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                if c.name == cname and c.state == "active":
+                    found = True
+                    break
+        assert found, f"{cname} not found!"
+
+    def test_check_if_msgs_published(self):
+        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 2, "Wrong number of joints in message"
+        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
+        wait_for_topics.shutdown()
+
+
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
+
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_7/CMakeLists.txt
+++ b/example_7/CMakeLists.txt
@@ -28,6 +28,7 @@ set(CONTROLLER_INCLUDE_DEPENDS
 )
 
 # find dependencies
+find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${HW_IF_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/example_7/CMakeLists.txt
+++ b/example_7/CMakeLists.txt
@@ -101,6 +101,7 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(example_7_urdf_xacro test/test_urdf_xacro.py)
   ament_add_pytest_test(view_example_7_launch test/test_view_robot_launch.py)
+  ament_add_pytest_test(run_example_7_launch test/test_r6bot_controller_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_7/bringup/launch/r6bot_controller.launch.py
+++ b/example_7/bringup/launch/r6bot_controller.launch.py
@@ -13,15 +13,25 @@
 # limitations under the License.
 
 from launch import LaunchDescription
-from launch.actions import RegisterEventHandler
+from launch.actions import RegisterEventHandler, DeclareLaunchArgument
+from launch.conditions import IfCondition
 from launch.event_handlers import OnProcessExit
-from launch.substitutions import Command, FindExecutable, PathJoinSubstitution
+from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, LaunchConfiguration
 
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
 
 
 def generate_launch_description():
+    # Declare arguments
+    declared_arguments = []
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "gui",
+            default_value="true",
+            description="Start RViz2 automatically with this launch file.",
+        )
+    )
     # Get URDF via xacro
     robot_description_content = Command(
         [
@@ -67,12 +77,15 @@ def generate_launch_description():
         output="both",
         parameters=[robot_description],
     )
+
+    gui = LaunchConfiguration("gui")
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
         name="rviz2",
         output="log",
         arguments=["-d", rviz_config_file],
+        condition=IfCondition(gui),
     )
 
     joint_state_broadcaster_spawner = Node(
@@ -111,4 +124,4 @@ def generate_launch_description():
         delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
     ]
 
-    return LaunchDescription(nodes)
+    return LaunchDescription(declared_arguments + nodes)

--- a/example_7/bringup/launch/r6bot_controller.launch.py
+++ b/example_7/bringup/launch/r6bot_controller.launch.py
@@ -108,20 +108,21 @@ def generate_launch_description():
         )
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_joint_state_broadcaster_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[robot_controller_spawner],
+            target_action=robot_controller_spawner,
+            on_exit=[joint_state_broadcaster_spawner],
         )
     )
 
     nodes = [
         control_node,
         robot_state_pub_node,
-        joint_state_broadcaster_spawner,
+        robot_controller_spawner,
         delay_rviz_after_joint_state_broadcaster_spawner,
-        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
+        delay_joint_state_broadcaster_after_robot_controller_spawner,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/example_7/description/ros2_control/r6bot.ros2_control.xacro
+++ b/example_7/description/ros2_control/r6bot.ros2_control.xacro
@@ -11,8 +11,8 @@
 
       <joint name="joint_1">
         <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
+          <param name="min">${-2*pi}</param>
+          <param name="max">${2*pi}</param>
         </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.15</param>
@@ -26,8 +26,8 @@
 
       <joint name="joint_2">
         <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
+          <param name="min">${-2*pi}</param>
+          <param name="max">${2*pi}</param>
         </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.15</param>
@@ -41,8 +41,8 @@
 
       <joint name="joint_3">
         <command_interface name="position">
-          <param name="min">{-pi}</param>
-          <param name="max">{pi}</param>
+          <param name="min">${-pi}</param>
+          <param name="max">${pi}</param>
         </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.15</param>
@@ -56,8 +56,8 @@
 
       <joint name="joint_4">
         <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
+          <param name="min">${-2*pi}</param>
+          <param name="max">${2*pi}</param>
         </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.2</param>
@@ -71,8 +71,8 @@
 
       <joint name="joint_5">
         <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
+          <param name="min">${-2*pi}</param>
+          <param name="max">${2*pi}</param>
         </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.2</param>
@@ -86,8 +86,8 @@
 
       <joint name="joint_6">
         <command_interface name="position">
-          <param name="min">{-2*pi}</param>
-          <param name="max">{2*pi}</param>
+          <param name="min">${-2*pi}</param>
+          <param name="max">${2*pi}</param>
         </command_interface>
         <command_interface name="velocity">
           <param name="min">-3.2</param>

--- a/example_7/package.xml
+++ b/example_7/package.xml
@@ -39,11 +39,11 @@
   <exec_depend>urdf</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
+  <test_depend>ros2_control_demo_testing</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/example_7/package.xml
+++ b/example_7/package.xml
@@ -40,7 +40,6 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>ros2_control_demo_testing</test_depend>

--- a/example_7/package.xml
+++ b/example_7/package.xml
@@ -15,6 +15,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>control_msgs</depend>
   <depend>controller_interface</depend>
   <depend>hardware_interface</depend>

--- a/example_7/test/test_r6bot_controller_launch.py
+++ b/example_7/test/test_r6bot_controller_launch.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import os
+import pytest
+import unittest
+import time
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+
+# import launch_testing.markers
+from launch_testing_ros import WaitForTopics
+from controller_manager.controller_manager_services import list_controllers
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("ros2_control_demo_example_7"),
+                "launch/r6bot_controller.launch.py",
+            )
+        ),
+        launch_arguments={"gui": "false"}.items(),
+    )
+
+    return LaunchDescription([launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "robot_state_publisher" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "robot_state_publisher not found!"
+
+    def test_controller_running(self, proc_output):
+
+        cname = "r6bot_controller"
+
+        start = time.time()
+        found = False
+        while time.time() - start < 10.0 and not found:
+            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                if c.name == cname and c.state == "active":
+                    found = True
+                    break
+        assert found, f"{cname} not found!"
+
+    def test_check_if_msgs_published(self):
+        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 6, "Wrong number of joints in message"
+        assert set(msg.name) == {
+            "joint_1",
+            "joint_2",
+            "joint_3",
+            "joint_4",
+            "joint_5",
+            "joint_6",
+        }, "Wrong joint names"
+        wait_for_topics.shutdown()
+
+
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
+
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_7/test/test_r6bot_controller_launch.py
+++ b/example_7/test/test_r6bot_controller_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-import launch_testing.markers
+# import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -93,10 +93,11 @@ class TestFixture(unittest.TestCase):
         )
 
 
-@launch_testing.post_shutdown_test()
-# These tests are run after the processes in generate_test_description() have shutdown.
-class TestDescriptionCraneShutdown(unittest.TestCase):
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
 
-    def test_exit_codes(self, proc_info):
-        """Check if the processes exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info)
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_7/test/test_r6bot_controller_launch.py
+++ b/example_7/test/test_r6bot_controller_launch.py
@@ -40,11 +40,9 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
-from launch_testing_ros import WaitForTopics
-from controller_manager.controller_manager_services import list_controllers
 import rclpy
 from rclpy.node import Node
-from sensor_msgs.msg import JointState
+from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -78,41 +76,21 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         start = time.time()
         found = False
-        while time.time() - start < 2.0 and not found:
+        while time.time() - start < 5.0 and not found:
             found = "robot_state_publisher" in self.node.get_node_names()
             time.sleep(0.1)
         assert found, "robot_state_publisher not found!"
 
     def test_controller_running(self, proc_output):
 
-        cname = "r6bot_controller"
+        cnames = ["r6bot_controller", "joint_state_broadcaster"]
 
-        start = time.time()
-        found = False
-        while time.time() - start < 10.0 and not found:
-            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
-            assert controllers, "No controllers found!"
-            for c in controllers:
-                if c.name == cname and c.state == "active":
-                    found = True
-                    break
-        assert found, f"{cname} not found!"
+        check_controllers_running(self.node, cnames)
 
     def test_check_if_msgs_published(self):
-        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
-        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
-        msgs = wait_for_topics.received_messages("/joint_states")
-        msg = msgs[0]
-        assert len(msg.name) == 6, "Wrong number of joints in message"
-        assert set(msg.name) == {
-            "joint_1",
-            "joint_2",
-            "joint_3",
-            "joint_4",
-            "joint_5",
-            "joint_6",
-        }, "Wrong joint names"
-        wait_for_topics.shutdown()
+        check_if_js_published(
+            "/joint_states", ["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"]
+        )
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore

--- a/example_7/test/test_r6bot_controller_launch.py
+++ b/example_7/test/test_r6bot_controller_launch.py
@@ -31,7 +31,6 @@
 import os
 import pytest
 import unittest
-import time
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -42,7 +41,11 @@ from launch_testing.actions import ReadyToTest
 # import launch_testing.markers
 import rclpy
 from rclpy.node import Node
-from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
+from ros2_control_demo_testing.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -74,12 +77,7 @@ class TestFixture(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running(self, proc_output):
 

--- a/example_7/test/test_r6bot_controller_launch.py
+++ b/example_7/test/test_r6bot_controller_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -93,11 +93,10 @@ class TestFixture(unittest.TestCase):
         )
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_8/CMakeLists.txt
+++ b/example_8/CMakeLists.txt
@@ -18,6 +18,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # find dependencies
+find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/example_8/CMakeLists.txt
+++ b/example_8/CMakeLists.txt
@@ -67,6 +67,7 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(example_8_urdf_xacro test/test_urdf_xacro.py)
   ament_add_pytest_test(view_example_8_launch test/test_view_robot_launch.py)
+  ament_add_pytest_test(run_example_8_launch test/test_rrbot_transmissions_system_position_only_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_8/bringup/launch/rrbot_transmissions_system_position_only.launch.py
+++ b/example_8/bringup/launch/rrbot_transmissions_system_position_only.launch.py
@@ -134,20 +134,21 @@ def generate_launch_description():
         )
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_joint_state_broadcaster_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[robot_controller_spawner],
+            target_action=robot_controller_spawner,
+            on_exit=[joint_state_broadcaster_spawner],
         )
     )
 
     nodes = [
         control_node,
         robot_state_pub_node,
-        joint_state_broadcaster_spawner,
+        robot_controller_spawner,
         delay_rviz_after_joint_state_broadcaster_spawner,
-        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
+        delay_joint_state_broadcaster_after_robot_controller_spawner,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/example_8/package.xml
+++ b/example_8/package.xml
@@ -34,7 +34,6 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>ros2_control_demo_testing</test_depend>

--- a/example_8/package.xml
+++ b/example_8/package.xml
@@ -33,11 +33,11 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
+  <test_depend>ros2_control_demo_testing</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/example_8/package.xml
+++ b/example_8/package.xml
@@ -15,6 +15,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/example_8/test/test_rrbot_transmissions_system_position_only_launch.py
+++ b/example_8/test/test_rrbot_transmissions_system_position_only_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,11 +91,10 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_8/test/test_rrbot_transmissions_system_position_only_launch.py
+++ b/example_8/test/test_rrbot_transmissions_system_position_only_launch.py
@@ -40,11 +40,9 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
-from launch_testing_ros import WaitForTopics
-from controller_manager.controller_manager_services import list_controllers
 import rclpy
 from rclpy.node import Node
-from sensor_msgs.msg import JointState
+from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -78,34 +76,19 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         start = time.time()
         found = False
-        while time.time() - start < 2.0 and not found:
+        while time.time() - start < 5.0 and not found:
             found = "robot_state_publisher" in self.node.get_node_names()
             time.sleep(0.1)
         assert found, "robot_state_publisher not found!"
 
     def test_controller_running(self, proc_output):
 
-        cname = "forward_position_controller"
+        cnames = ["forward_position_controller", "joint_state_broadcaster"]
 
-        start = time.time()
-        found = False
-        while time.time() - start < 10.0 and not found:
-            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
-            assert controllers, "No controllers found!"
-            for c in controllers:
-                if c.name == cname and c.state == "active":
-                    found = True
-                    break
-        assert found, f"{cname} not found!"
+        check_controllers_running(self.node, cnames)
 
     def test_check_if_msgs_published(self):
-        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
-        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
-        msgs = wait_for_topics.received_messages("/joint_states")
-        msg = msgs[0]
-        assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
-        wait_for_topics.shutdown()
+        check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore

--- a/example_8/test/test_rrbot_transmissions_system_position_only_launch.py
+++ b/example_8/test/test_rrbot_transmissions_system_position_only_launch.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import os
+import pytest
+import unittest
+import time
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+
+# import launch_testing.markers
+from launch_testing_ros import WaitForTopics
+from controller_manager.controller_manager_services import list_controllers
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("ros2_control_demo_example_8"),
+                "launch/rrbot_transmissions_system_position_only.launch.py",
+            )
+        ),
+        launch_arguments={"gui": "false"}.items(),
+    )
+
+    return LaunchDescription([launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "robot_state_publisher" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "robot_state_publisher not found!"
+
+    def test_controller_running(self, proc_output):
+
+        cname = "forward_position_controller"
+
+        start = time.time()
+        found = False
+        while time.time() - start < 10.0 and not found:
+            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                if c.name == cname and c.state == "active":
+                    found = True
+                    break
+        assert found, f"{cname} not found!"
+
+    def test_check_if_msgs_published(self):
+        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 2, "Wrong number of joints in message"
+        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
+        wait_for_topics.shutdown()
+
+
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
+
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_8/test/test_rrbot_transmissions_system_position_only_launch.py
+++ b/example_8/test/test_rrbot_transmissions_system_position_only_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-import launch_testing.markers
+# import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,10 +91,11 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-@launch_testing.post_shutdown_test()
-# These tests are run after the processes in generate_test_description() have shutdown.
-class TestDescriptionCraneShutdown(unittest.TestCase):
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
 
-    def test_exit_codes(self, proc_info):
-        """Check if the processes exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info)
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_8/test/test_rrbot_transmissions_system_position_only_launch.py
+++ b/example_8/test/test_rrbot_transmissions_system_position_only_launch.py
@@ -31,7 +31,6 @@
 import os
 import pytest
 import unittest
-import time
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -42,7 +41,11 @@ from launch_testing.actions import ReadyToTest
 # import launch_testing.markers
 import rclpy
 from rclpy.node import Node
-from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
+from ros2_control_demo_testing.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -74,12 +77,7 @@ class TestFixture(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running(self, proc_output):
 

--- a/example_9/CMakeLists.txt
+++ b/example_9/CMakeLists.txt
@@ -17,6 +17,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # find dependencies
+find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
   find_package(${Dependency} REQUIRED)

--- a/example_9/CMakeLists.txt
+++ b/example_9/CMakeLists.txt
@@ -66,6 +66,7 @@ if(BUILD_TESTING)
 
   ament_add_pytest_test(example_9_urdf_xacro test/test_urdf_xacro.py)
   ament_add_pytest_test(view_example_9_launch test/test_view_robot_launch.py)
+  ament_add_pytest_test(run_example_9_launch test/test_rrbot_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_9/bringup/launch/rrbot.launch.py
+++ b/example_9/bringup/launch/rrbot.launch.py
@@ -106,20 +106,21 @@ def generate_launch_description():
         )
     )
 
-    # Delay start of robot_controller after `joint_state_broadcaster`
-    delay_robot_controller_spawner_after_joint_state_broadcaster_spawner = RegisterEventHandler(
+    # Delay start of joint_state_broadcaster after `robot_controller`
+    # TODO(anyone): This is a workaround for flaky tests. Remove when fixed.
+    delay_joint_state_broadcaster_after_robot_controller_spawner = RegisterEventHandler(
         event_handler=OnProcessExit(
-            target_action=joint_state_broadcaster_spawner,
-            on_exit=[robot_controller_spawner],
+            target_action=robot_controller_spawner,
+            on_exit=[joint_state_broadcaster_spawner],
         )
     )
 
     nodes = [
         control_node,
         robot_state_pub_node,
-        joint_state_broadcaster_spawner,
+        robot_controller_spawner,
         delay_rviz_after_joint_state_broadcaster_spawner,
-        delay_robot_controller_spawner_after_joint_state_broadcaster_spawner,
+        delay_joint_state_broadcaster_after_robot_controller_spawner,
     ]
 
     return LaunchDescription(declared_arguments + nodes)

--- a/example_9/package.xml
+++ b/example_9/package.xml
@@ -35,11 +35,11 @@
   <exec_depend>rviz2</exec_depend>
   <exec_depend>xacro</exec_depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
+  <test_depend>ros2_control_demo_testing</test_depend>
   <test_depend>xacro</test_depend>
 
   <export>

--- a/example_9/package.xml
+++ b/example_9/package.xml
@@ -16,6 +16,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>backward_ros</depend>
   <depend>hardware_interface</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/example_9/package.xml
+++ b/example_9/package.xml
@@ -36,7 +36,6 @@
   <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_cmake_pytest</test_depend>
-  <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>launch_testing_ros</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>ros2_control_demo_testing</test_depend>

--- a/example_9/test/test_rrbot_launch.py
+++ b/example_9/test/test_rrbot_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,11 +91,10 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_9/test/test_rrbot_launch.py
+++ b/example_9/test/test_rrbot_launch.py
@@ -40,11 +40,9 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
-from launch_testing_ros import WaitForTopics
-from controller_manager.controller_manager_services import list_controllers
 import rclpy
 from rclpy.node import Node
-from sensor_msgs.msg import JointState
+from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -78,34 +76,19 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         start = time.time()
         found = False
-        while time.time() - start < 2.0 and not found:
+        while time.time() - start < 5.0 and not found:
             found = "robot_state_publisher" in self.node.get_node_names()
             time.sleep(0.1)
         assert found, "robot_state_publisher not found!"
 
     def test_controller_running(self, proc_output):
 
-        cname = "forward_position_controller"
+        cnames = ["forward_position_controller", "joint_state_broadcaster"]
 
-        start = time.time()
-        found = False
-        while time.time() - start < 10.0 and not found:
-            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
-            assert controllers, "No controllers found!"
-            for c in controllers:
-                if c.name == cname and c.state == "active":
-                    found = True
-                    break
-        assert found, f"{cname} not found!"
+        check_controllers_running(self.node, cnames)
 
     def test_check_if_msgs_published(self):
-        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
-        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
-        msgs = wait_for_topics.received_messages("/joint_states")
-        msg = msgs[0]
-        assert len(msg.name) == 2, "Wrong number of joints in message"
-        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
-        wait_for_topics.shutdown()
+        check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore

--- a/example_9/test/test_rrbot_launch.py
+++ b/example_9/test/test_rrbot_launch.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-import launch_testing.markers
+# import launch_testing.markers
 import rclpy
 from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
@@ -91,10 +91,11 @@ class TestFixture(unittest.TestCase):
         check_if_js_published("/joint_states", ["joint1", "joint2"])
 
 
-@launch_testing.post_shutdown_test()
-# These tests are run after the processes in generate_test_description() have shutdown.
-class TestDescriptionCraneShutdown(unittest.TestCase):
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
 
-    def test_exit_codes(self, proc_info):
-        """Check if the processes exited normally."""
-        launch_testing.asserts.assertExitCodes(proc_info)
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_9/test/test_rrbot_launch.py
+++ b/example_9/test/test_rrbot_launch.py
@@ -31,7 +31,6 @@
 import os
 import pytest
 import unittest
-import time
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
@@ -42,7 +41,11 @@ from launch_testing.actions import ReadyToTest
 # import launch_testing.markers
 import rclpy
 from rclpy.node import Node
-from ros2_control_demo_testing.test_utils import check_controllers_running, check_if_js_published
+from ros2_control_demo_testing.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
 
 
 # Executes the given launch file and checks if all nodes can be started
@@ -74,12 +77,7 @@ class TestFixture(unittest.TestCase):
         rclpy.shutdown()
 
     def test_node_start(self, proc_output):
-        start = time.time()
-        found = False
-        while time.time() - start < 5.0 and not found:
-            found = "robot_state_publisher" in self.node.get_node_names()
-            time.sleep(0.1)
-        assert found, "robot_state_publisher not found!"
+        check_node_running(self.node, "robot_state_publisher")
 
     def test_controller_running(self, proc_output):
 

--- a/example_9/test/test_rrbot_launch.py
+++ b/example_9/test/test_rrbot_launch.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import os
+import pytest
+import unittest
+import time
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_testing.actions import ReadyToTest
+
+# import launch_testing.markers
+from launch_testing_ros import WaitForTopics
+from controller_manager.controller_manager_services import list_controllers
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import JointState
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("ros2_control_demo_example_9"),
+                "launch/rrbot.launch.py",
+            )
+        ),
+        launch_arguments={"gui": "false"}.items(),
+    )
+
+    return LaunchDescription([launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+
+    def setUp(self):
+        rclpy.init()
+        self.node = Node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+        rclpy.shutdown()
+
+    def test_node_start(self, proc_output):
+        start = time.time()
+        found = False
+        while time.time() - start < 2.0 and not found:
+            found = "robot_state_publisher" in self.node.get_node_names()
+            time.sleep(0.1)
+        assert found, "robot_state_publisher not found!"
+
+    def test_controller_running(self, proc_output):
+
+        cname = "forward_position_controller"
+
+        start = time.time()
+        found = False
+        while time.time() - start < 10.0 and not found:
+            controllers = list_controllers(self.node, "controller_manager", 5.0).controller
+            assert controllers, "No controllers found!"
+            for c in controllers:
+                if c.name == cname and c.state == "active":
+                    found = True
+                    break
+        assert found, f"{cname} not found!"
+
+    def test_check_if_msgs_published(self):
+        wait_for_topics = WaitForTopics([("/joint_states", JointState)], timeout=15.0)
+        assert wait_for_topics.wait(), "Topic '/joint_states' not found!"
+        msgs = wait_for_topics.received_messages("/joint_states")
+        msg = msgs[0]
+        assert len(msg.name) == 2, "Wrong number of joints in message"
+        assert set(msg.name) == {"joint1", "joint2"}, "Wrong joint names"
+        wait_for_topics.shutdown()
+
+
+# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
+# @launch_testing.post_shutdown_test()
+# # These tests are run after the processes in generate_test_description() have shutdown.
+# class TestDescriptionCraneShutdown(unittest.TestCase):
+
+#     def test_exit_codes(self, proc_info):
+#         """Check if the processes exited normally."""
+#         launch_testing.asserts.assertExitCodes(proc_info)

--- a/ros2_control_demo_testing/package.xml
+++ b/ros2_control_demo_testing/package.xml
@@ -8,7 +8,7 @@
   <license>Apache-2.0</license>
 
   <test_depend>sensor_msgs</test_depend>
-  <test_depend>launch_testing</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>controller_manager</test_depend>
 
   <export>

--- a/ros2_control_demo_testing/package.xml
+++ b/ros2_control_demo_testing/package.xml
@@ -7,14 +7,9 @@
   <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
   <license>Apache-2.0</license>
 
-  <depend>sensor_msgs</depend>
-  <depend>launch_testing</depend>
-  <depend>controller_manger</depend>
-
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
-  <test_depend>python3-pytest</test_depend>
+  <test_depend>sensor_msgs</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>controller_manager</test_depend>
 
   <export>
     <build_type>ament_python</build_type>

--- a/ros2_control_demo_testing/package.xml
+++ b/ros2_control_demo_testing/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros2_control_demo_testing</name>
+  <version>0.0.0</version>
+  <description>Utilities for launch testing</description>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <license>Apache-2.0</license>
+
+  <depend>sensor_msgs</depend>
+  <depend>launch_testing</depend>
+  <depend>controller_manger</depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/ros2_control_demo_testing/ros2_control_demo_testing/test_utils.py
+++ b/ros2_control_demo_testing/ros2_control_demo_testing/test_utils.py
@@ -86,7 +86,7 @@ def check_controllers_running(node, cnames, namespace=""):
 
 
 def check_if_js_published(topic, joint_names):
-    wait_for_topics = WaitForTopics([(topic, JointState)], timeout=15.0)
+    wait_for_topics = WaitForTopics([(topic, JointState)], timeout=20.0)
     assert wait_for_topics.wait(), f"Topic '{topic}' not found!"
     msgs = wait_for_topics.received_messages(topic)
     msg = msgs[0]

--- a/ros2_control_demo_testing/ros2_control_demo_testing/test_utils.py
+++ b/ros2_control_demo_testing/ros2_control_demo_testing/test_utils.py
@@ -91,5 +91,6 @@ def check_if_js_published(topic, joint_names):
     msgs = wait_for_topics.received_messages(topic)
     msg = msgs[0]
     assert len(msg.name) == len(joint_names), "Wrong number of joints in message"
-    assert msg.name == joint_names, "Wrong joint names"
+    # use a set to compare the joint names, as the order might be different
+    assert set(msg.name) == set(joint_names), "Wrong joint names"
     wait_for_topics.shutdown()

--- a/ros2_control_demo_testing/ros2_control_demo_testing/test_utils.py
+++ b/ros2_control_demo_testing/ros2_control_demo_testing/test_utils.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+import time
+
+from launch_testing_ros import WaitForTopics
+from sensor_msgs.msg import JointState
+from controller_manager.controller_manager_services import list_controllers
+
+
+def check_controllers_running(node, cnames, namespace=""):
+
+    # wait for controller to be loaded before we call the CM services
+    found = {cname: False for cname in cnames}  # Define 'found' as a dictionary
+    start = time.time()
+    # namespace is either "/" (empty) or "/ns" if set
+    if namespace:
+        namespace_api = namespace
+        if not namespace_api.startswith("/"):
+            namespace_api = "/" + namespace_api
+        if namespace.endswith("/"):
+            namespace_api = namespace_api[:-1]
+    else:
+        namespace_api = "/"
+
+    while time.time() - start < 10.0 and not all(found.values()):
+        node_names_namespaces = node.get_node_names_and_namespaces()
+        for cname in cnames:
+            if any(name == cname and ns == namespace_api for name, ns in node_names_namespaces):
+                found[cname] = True
+        time.sleep(0.1)
+    assert all(
+        found.values()
+    ), f"Controller node(s) not found: {', '.join(["ns: " + namespace_api + ", ctrl:" + cname for cname, is_found in found.items() if not is_found])}, but seeing {node.get_node_names_and_namespaces()}"
+
+    found = {cname: False for cname in cnames}  # Define 'found' as a dictionary
+    start = time.time()
+    # namespace is either "/" (empty) or "/ns" if set
+    if not namespace:
+        cm = "controller_manager"
+    else:
+        if namespace.endswith("/"):
+            cm = namespace + "controller_manager"
+        else:
+            cm = namespace + "/controller_manager"
+    while time.time() - start < 10.0 and not all(found.values()):
+        controllers = list_controllers(node, cm, 5.0).controller
+        assert controllers, "No controllers found!"
+        for c in controllers:
+            for cname in cnames:
+                if c.name == cname and c.state == "active":
+                    found[cname] = True
+                    break
+        time.sleep(0.1)
+
+    assert all(
+        found.values()
+    ), f"Controller(s) not found or not active: {', '.join([cname for cname, is_found in found.items() if not is_found])}"
+
+
+def check_if_js_published(topic, joint_names):
+    wait_for_topics = WaitForTopics([(topic, JointState)], timeout=15.0)
+    assert wait_for_topics.wait(), f"Topic '{topic}' not found!"
+    msgs = wait_for_topics.received_messages(topic)
+    msg = msgs[0]
+    assert len(msg.name) == len(joint_names), "Wrong number of joints in message"
+    assert msg.name == joint_names, "Wrong joint names"
+    wait_for_topics.shutdown()

--- a/ros2_control_demo_testing/ros2_control_demo_testing/test_utils.py
+++ b/ros2_control_demo_testing/ros2_control_demo_testing/test_utils.py
@@ -35,6 +35,16 @@ from sensor_msgs.msg import JointState
 from controller_manager.controller_manager_services import list_controllers
 
 
+def check_node_running(node, node_name, timeout=5.0):
+
+    start = time.time()
+    found = False
+    while time.time() - start < timeout and not found:
+        found = node_name in node.get_node_names()
+        time.sleep(0.1)
+    assert found, f"{node_name} not found!"
+
+
 def check_controllers_running(node, cnames, namespace=""):
 
     # wait for controller to be loaded before we call the CM services

--- a/ros2_control_demo_testing/setup.cfg
+++ b/ros2_control_demo_testing/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/ros2_control_demo_testing
+[install]
+install_scripts=$base/lib/ros2_control_demo_testing

--- a/ros2_control_demo_testing/setup.py
+++ b/ros2_control_demo_testing/setup.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2024 AIT - Austrian Institute of Technology GmbH
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#
+#    * Redistributions in binary form must reproduce the above copyright
+#      notice, this list of conditions and the following disclaimer in the
+#      documentation and/or other materials provided with the distribution.
+#
+#    * Neither the name of the {copyright_holder} nor the names of its
+#      contributors may be used to endorse or promote products derived from
+#      this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: Christoph Froehlich
+
+from setuptools import find_packages, setup
+
+package_name = "ros2_control_demo_testing"
+
+setup(
+    name=package_name,
+    version="0.0.0",
+    packages=find_packages(exclude=["test"]),
+    data_files=[
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ("share/" + package_name, ["package.xml"]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    maintainer="Christoph Froehlich",
+    maintainer_email="christoph.froehlich@ait.ac.at",
+    description="Utilities for launch testing",
+    license="Apache-2.0",
+    tests_require=["pytest"],
+    entry_points={
+        "console_scripts": [],
+    },
+)


### PR DESCRIPTION
The old tests only test the URDF and if the view_robot.launch.py doesn't have a python syntax error and launch_ros does not complain.

The new tests for the main launch file now also check

- The python syntax is correct
- robot_state_publisher node is available
- the controller for this example is active
- joint_states topic is available and has the correct joints

closes #422 

Deactivated tests or other temporary measures: I'll push draft PRs after merging this to not forget that!

- example_14 exit codes due to #542 
- example_15 because of bug in spawners, may be solved with #502 
- [0b8382b](https://github.com/ros-controls/ros2_control_demos/pull/540/commits/0b8382bb1a5f05820bc0af4b5931bdc09a77bb4e) can be reverted once https://github.com/ros2/rclpy/issues/1320 is fixed

