### PR TITLE
Ex7: Remove visibility macro

### DIFF
--- a/example_7/hardware/include/ros2_control_demo_example_7/r6bot_hardware.hpp
+++ b/example_7/hardware/include/ros2_control_demo_example_7/r6bot_hardware.hpp
@@ -31,7 +31,7 @@ namespace ros2_control_demo_example_7
 {
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
 
-class HARDWARE_INTERFACE_PUBLIC RobotSystem : public hardware_interface::SystemInterface
+class RobotSystem : public hardware_interface::SystemInterface
 {
 public:
   CallbackReturn on_init(const hardware_interface::HardwareInfo & info) override;


### PR DESCRIPTION
As a consequence of https://github.com/ros-controls/ros2_control/pull/1627 there is an include for HARWARE_INTERFACE_PUBLIC missing, causing the build of example_7 to fail.