### PR TITLE
Fix double quotes in python file

### DIFF
--- a/ros2_control_demo_testing/ros2_control_demo_testing/test_utils.py
+++ b/ros2_control_demo_testing/ros2_control_demo_testing/test_utils.py
@@ -68,7 +68,7 @@ def check_controllers_running(node, cnames, namespace=""):
         time.sleep(0.1)
     assert all(
         found.values()
-    ), f"Controller node(s) not found: {', '.join(["ns: " + namespace_api + ", ctrl:" + cname for cname, is_found in found.items() if not is_found])}, but seeing {node.get_node_names_and_namespaces()}"
+    ), f"Controller node(s) not found: {', '.join(['ns: ' + namespace_api + ', ctrl:' + cname for cname, is_found in found.items() if not is_found])}, but seeing {node.get_node_names_and_namespaces()}"
 
     found = {cname: False for cname in cnames}  # Define 'found' as a dictionary
     start = time.time()


### PR DESCRIPTION
The code worked on noble/rolling but didn't on iron/humble at jammy. I added this already in #549 #550 but to be save I'd also push this on the rolling version.