### PR TITLE
[Example 13] Give the controller type as parameter in ctrl namespace

### DIFF
--- a/example_13/CMakeLists.txt
+++ b/example_13/CMakeLists.txt
@@ -9,6 +9,14 @@ endif()
 set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
+# Specify the required version of ros2_control
+find_package(ros2_control 4.0.0)
+# Handle the case where the required version is not found
+if(NOT ros2_control_FOUND)
+  message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
+  "Are you using the correct branch of the ros2_control_demos repository?")
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})

--- a/example_13/CMakeLists.txt
+++ b/example_13/CMakeLists.txt
@@ -10,9 +10,9 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # Specify the required version of ros2_control
-find_package(ros2_control 4.0.0)
+find_package(controller_manager 4.0.0)
 # Handle the case where the required version is not found
-if(NOT ros2_control_FOUND)
+if(NOT controller_manager_FOUND)
   message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
   "Are you using the correct branch of the ros2_control_demos repository?")
 endif()

--- a/example_13/bringup/config/three_robots_controllers.yaml
+++ b/example_13/bringup/config/three_robots_controllers.yaml
@@ -15,36 +15,6 @@ controller_manager:
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
 
-    # RRBot controllers
-    rrbot_joint_state_broadcaster:
-      type: joint_state_broadcaster/JointStateBroadcaster
-
-    rrbot_position_controller:
-      type: forward_command_controller/ForwardCommandController
-
-    rrbot_external_fts_broadcaster:
-      type: force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
-
-    # RRBot with sensor controllers
-    rrbot_with_sensor_joint_state_broadcaster:
-      type: joint_state_broadcaster/JointStateBroadcaster
-
-    rrbot_with_sensor_position_controller:
-      type: forward_command_controller/ForwardCommandController
-
-    rrbot_with_sensor_fts_broadcaster:
-      type: force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
-
-    # ThreeDofBot controllers
-    threedofbot_joint_state_broadcaster:
-      type: joint_state_broadcaster/JointStateBroadcaster
-
-    threedofbot_position_controller:
-      type: forward_command_controller/ForwardCommandController
-
-    threedofbot_pid_gain_controller:
-      type: forward_command_controller/ForwardCommandController
-
 # global joint_state_broadcaster
 # joint_state_broadcaster:
 #   ros__parameters:
@@ -53,6 +23,7 @@ controller_manager:
 # RRBot controllers
 rrbot_joint_state_broadcaster:
   ros__parameters:
+    type: joint_state_broadcaster/JointStateBroadcaster
     use_local_topics: True
     joints:
       - rrbot_joint1
@@ -62,6 +33,7 @@ rrbot_joint_state_broadcaster:
 
 rrbot_position_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - rrbot_joint1
       - rrbot_joint2
@@ -69,6 +41,7 @@ rrbot_position_controller:
 
 rrbot_external_fts_broadcaster:
   ros__parameters:
+    type: force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
     sensor_name: rrbot_tcp_fts_sensor
     frame_id: rrbot_tool_link
 
@@ -76,6 +49,7 @@ rrbot_external_fts_broadcaster:
 # RRBot with sensor controllers
 rrbot_with_sensor_joint_state_broadcaster:
   ros__parameters:
+    type: joint_state_broadcaster/JointStateBroadcaster
     use_local_topics: True
     joints:
       - rrbot_with_sensor_joint1
@@ -85,6 +59,7 @@ rrbot_with_sensor_joint_state_broadcaster:
 
 rrbot_with_sensor_position_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - rrbot_with_sensor_joint1
       - rrbot_with_sensor_joint2
@@ -92,6 +67,7 @@ rrbot_with_sensor_position_controller:
 
 rrbot_with_sensor_fts_broadcaster:
   ros__parameters:
+    type: force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
     interface_names.force.x: rrbot_with_sensor_tcp_fts_sensor/force.x
     interface_names.torque.z: rrbot_with_sensor_tcp_fts_sensor/torque.z
     frame_id: rrbot_with_sensor_tool_link
@@ -99,6 +75,7 @@ rrbot_with_sensor_fts_broadcaster:
 # ThreeDofBot controllers
 threedofbot_joint_state_broadcaster:
   ros__parameters:
+    type: joint_state_broadcaster/JointStateBroadcaster
     use_local_topics: True
     joints:
       - threedofbot_joint1
@@ -110,6 +87,7 @@ threedofbot_joint_state_broadcaster:
 
 threedofbot_position_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - threedofbot_joint1
       - threedofbot_joint2
@@ -118,6 +96,7 @@ threedofbot_position_controller:
 
 threedofbot_pid_gain_controller:
   ros__parameters:
+    type: forward_command_controller/ForwardCommandController
     joints:
       - threedofbot_joint1
       - threedofbot_joint2

--- a/example_13/bringup/launch/three_robots.launch.py
+++ b/example_13/bringup/launch/three_robots.launch.py
@@ -117,25 +117,25 @@ def generate_launch_description():
     rrbot_joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["rrbot_joint_state_broadcaster"],
+        arguments=["rrbot_joint_state_broadcaster", "--param-file", robot_controllers],
     )
     rrbot_position_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["rrbot_position_controller"],
+        arguments=["rrbot_position_controller", "--param-file", robot_controllers],
     )
     # External FTS broadcaster
     rrbot_external_fts_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["rrbot_external_fts_broadcaster"],
+        arguments=["rrbot_external_fts_broadcaster", "--param-file", robot_controllers],
     )
 
     # RRBot controllers
     rrbot_with_sensor_joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["rrbot_with_sensor_joint_state_broadcaster"],
+        arguments=["rrbot_with_sensor_joint_state_broadcaster", "--param-file", robot_controllers],
     )
     rrbot_with_sensor_position_controller_spawner = Node(
         package="controller_manager",
@@ -143,12 +143,14 @@ def generate_launch_description():
         arguments=[
             "rrbot_with_sensor_position_controller",
             "--inactive",
+            "--param-file",
+            robot_controllers,
         ],
     )
     rrbot_with_sensor_fts_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["rrbot_with_sensor_fts_broadcaster"],
+        arguments=["rrbot_with_sensor_fts_broadcaster", "--param-file", robot_controllers],
     )
 
     # ThreeDofBot controllers
@@ -157,20 +159,30 @@ def generate_launch_description():
         executable="spawner",
         arguments=[
             "threedofbot_joint_state_broadcaster",
-            "-c",
-            "/controller_manager",
             "--inactive",
+            "--param-file",
+            robot_controllers,
         ],
     )
     threedofbot_position_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["threedofbot_position_controller", "--inactive"],
+        arguments=[
+            "threedofbot_position_controller",
+            "--inactive",
+            "--param-file",
+            robot_controllers,
+        ],
     )
     threedofbot_pid_gain_controller_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["threedofbot_pid_gain_controller", "--inactive"],
+        arguments=[
+            "threedofbot_pid_gain_controller",
+            "--inactive",
+            "--param-file",
+            robot_controllers,
+        ],
     )
 
     # Command publishers

--- a/example_13/test/test_three_robots_launch.py
+++ b/example_13/test/test_three_robots_launch.py
@@ -79,6 +79,9 @@ class TestFixture(unittest.TestCase):
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")
+        check_node_running(self.node, "rrbot_position_command_publisher")
+        check_node_running(self.node, "rrbot_with_sensor_position_command_publisher")
+        check_node_running(self.node, "threedofbot_position_command_publisher")
 
     def test_behavior(self, proc_output):
 


### PR DESCRIPTION
Applies changes similar to #502 to #417, but this can't be backported.