### PR TITLE
Add guards for correct version of ros2_control

### DIFF
--- a/example_1/CMakeLists.txt
+++ b/example_1/CMakeLists.txt
@@ -16,6 +16,14 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp_lifecycle
 )
 
+# Specify the required version of ros2_control
+find_package(ros2_control 4.0.0)
+# Handle the case where the required version is not found
+if(NOT ros2_control_FOUND)
+  message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
+  "Are you using the correct branch of the ros2_control_demos repository?")
+endif()
+
 # find dependencies
 find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)

--- a/example_1/CMakeLists.txt
+++ b/example_1/CMakeLists.txt
@@ -17,9 +17,9 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # Specify the required version of ros2_control
-find_package(ros2_control 4.0.0)
+find_package(controller_manager 4.0.0)
 # Handle the case where the required version is not found
-if(NOT ros2_control_FOUND)
+if(NOT controller_manager_FOUND)
   message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
   "Are you using the correct branch of the ros2_control_demos repository?")
 endif()

--- a/example_10/CMakeLists.txt
+++ b/example_10/CMakeLists.txt
@@ -19,6 +19,14 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   controller_interface
 )
 
+# Specify the required version of ros2_control
+find_package(ros2_control 4.0.0)
+# Handle the case where the required version is not found
+if(NOT ros2_control_FOUND)
+  message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
+  "Are you using the correct branch of the ros2_control_demos repository?")
+endif()
+
 # find dependencies
 find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)

--- a/example_10/CMakeLists.txt
+++ b/example_10/CMakeLists.txt
@@ -20,9 +20,9 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # Specify the required version of ros2_control
-find_package(ros2_control 4.0.0)
+find_package(controller_manager 4.0.0)
 # Handle the case where the required version is not found
-if(NOT ros2_control_FOUND)
+if(NOT controller_manager_FOUND)
   message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
   "Are you using the correct branch of the ros2_control_demos repository?")
 endif()

--- a/example_11/CMakeLists.txt
+++ b/example_11/CMakeLists.txt
@@ -16,6 +16,14 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp_lifecycle
 )
 
+# Specify the required version of ros2_control
+find_package(ros2_control 4.0.0)
+# Handle the case where the required version is not found
+if(NOT ros2_control_FOUND)
+  message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
+  "Are you using the correct branch of the ros2_control_demos repository?")
+endif()
+
 # find dependencies
 find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)

--- a/example_11/CMakeLists.txt
+++ b/example_11/CMakeLists.txt
@@ -17,9 +17,9 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # Specify the required version of ros2_control
-find_package(ros2_control 4.0.0)
+find_package(controller_manager 4.0.0)
 # Handle the case where the required version is not found
-if(NOT ros2_control_FOUND)
+if(NOT controller_manager_FOUND)
   message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
   "Are you using the correct branch of the ros2_control_demos repository?")
 endif()

--- a/example_12/CMakeLists.txt
+++ b/example_12/CMakeLists.txt
@@ -22,6 +22,14 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   std_msgs
 )
 
+# Specify the required version of ros2_control
+find_package(ros2_control 4.0.0)
+# Handle the case where the required version is not found
+if(NOT ros2_control_FOUND)
+  message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
+  "Are you using the correct branch of the ros2_control_demos repository?")
+endif()
+
 # find dependencies
 find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)

--- a/example_12/CMakeLists.txt
+++ b/example_12/CMakeLists.txt
@@ -23,9 +23,9 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # Specify the required version of ros2_control
-find_package(ros2_control 4.0.0)
+find_package(controller_manager 4.0.0)
 # Handle the case where the required version is not found
-if(NOT ros2_control_FOUND)
+if(NOT controller_manager_FOUND)
   message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
   "Are you using the correct branch of the ros2_control_demos repository?")
 endif()

--- a/example_14/CMakeLists.txt
+++ b/example_14/CMakeLists.txt
@@ -17,6 +17,14 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   realtime_tools
 )
 
+# Specify the required version of ros2_control
+find_package(ros2_control 4.0.0)
+# Handle the case where the required version is not found
+if(NOT ros2_control_FOUND)
+  message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
+  "Are you using the correct branch of the ros2_control_demos repository?")
+endif()
+
 # find dependencies
 find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)

--- a/example_14/CMakeLists.txt
+++ b/example_14/CMakeLists.txt
@@ -18,9 +18,9 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # Specify the required version of ros2_control
-find_package(ros2_control 4.0.0)
+find_package(controller_manager 4.0.0)
 # Handle the case where the required version is not found
-if(NOT ros2_control_FOUND)
+if(NOT controller_manager_FOUND)
   message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
   "Are you using the correct branch of the ros2_control_demos repository?")
 endif()

--- a/example_2/CMakeLists.txt
+++ b/example_2/CMakeLists.txt
@@ -16,6 +16,14 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp_lifecycle
 )
 
+# Specify the required version of ros2_control
+find_package(ros2_control 4.0.0)
+# Handle the case where the required version is not found
+if(NOT ros2_control_FOUND)
+  message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
+  "Are you using the correct branch of the ros2_control_demos repository?")
+endif()
+
 # find dependencies
 find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)

--- a/example_2/CMakeLists.txt
+++ b/example_2/CMakeLists.txt
@@ -17,9 +17,9 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # Specify the required version of ros2_control
-find_package(ros2_control 4.0.0)
+find_package(controller_manager 4.0.0)
 # Handle the case where the required version is not found
-if(NOT ros2_control_FOUND)
+if(NOT controller_manager_FOUND)
   message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
   "Are you using the correct branch of the ros2_control_demos repository?")
 endif()

--- a/example_3/CMakeLists.txt
+++ b/example_3/CMakeLists.txt
@@ -16,6 +16,14 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp_lifecycle
 )
 
+# Specify the required version of ros2_control
+find_package(ros2_control 4.0.0)
+# Handle the case where the required version is not found
+if(NOT ros2_control_FOUND)
+  message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
+  "Are you using the correct branch of the ros2_control_demos repository?")
+endif()
+
 # find dependencies
 find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)

--- a/example_3/CMakeLists.txt
+++ b/example_3/CMakeLists.txt
@@ -17,9 +17,9 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # Specify the required version of ros2_control
-find_package(ros2_control 4.0.0)
+find_package(controller_manager 4.0.0)
 # Handle the case where the required version is not found
-if(NOT ros2_control_FOUND)
+if(NOT controller_manager_FOUND)
   message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
   "Are you using the correct branch of the ros2_control_demos repository?")
 endif()

--- a/example_4/CMakeLists.txt
+++ b/example_4/CMakeLists.txt
@@ -16,6 +16,14 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp_lifecycle
 )
 
+# Specify the required version of ros2_control
+find_package(ros2_control 4.0.0)
+# Handle the case where the required version is not found
+if(NOT ros2_control_FOUND)
+  message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
+  "Are you using the correct branch of the ros2_control_demos repository?")
+endif()
+
 # find dependencies
 find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)

--- a/example_4/CMakeLists.txt
+++ b/example_4/CMakeLists.txt
@@ -17,9 +17,9 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # Specify the required version of ros2_control
-find_package(ros2_control 4.0.0)
+find_package(controller_manager 4.0.0)
 # Handle the case where the required version is not found
-if(NOT ros2_control_FOUND)
+if(NOT controller_manager_FOUND)
   message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
   "Are you using the correct branch of the ros2_control_demos repository?")
 endif()

--- a/example_5/CMakeLists.txt
+++ b/example_5/CMakeLists.txt
@@ -16,6 +16,14 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp_lifecycle
 )
 
+# Specify the required version of ros2_control
+find_package(ros2_control 4.0.0)
+# Handle the case where the required version is not found
+if(NOT ros2_control_FOUND)
+  message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
+  "Are you using the correct branch of the ros2_control_demos repository?")
+endif()
+
 # find dependencies
 find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)

--- a/example_5/CMakeLists.txt
+++ b/example_5/CMakeLists.txt
@@ -17,9 +17,9 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # Specify the required version of ros2_control
-find_package(ros2_control 4.0.0)
+find_package(controller_manager 4.0.0)
 # Handle the case where the required version is not found
-if(NOT ros2_control_FOUND)
+if(NOT controller_manager_FOUND)
   message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
   "Are you using the correct branch of the ros2_control_demos repository?")
 endif()

--- a/example_6/CMakeLists.txt
+++ b/example_6/CMakeLists.txt
@@ -16,6 +16,14 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp_lifecycle
 )
 
+# Specify the required version of ros2_control
+find_package(ros2_control 4.0.0)
+# Handle the case where the required version is not found
+if(NOT ros2_control_FOUND)
+  message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
+  "Are you using the correct branch of the ros2_control_demos repository?")
+endif()
+
 # find dependencies
 find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)

--- a/example_6/CMakeLists.txt
+++ b/example_6/CMakeLists.txt
@@ -17,9 +17,9 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # Specify the required version of ros2_control
-find_package(ros2_control 4.0.0)
+find_package(controller_manager 4.0.0)
 # Handle the case where the required version is not found
-if(NOT ros2_control_FOUND)
+if(NOT controller_manager_FOUND)
   message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
   "Are you using the correct branch of the ros2_control_demos repository?")
 endif()

--- a/example_7/CMakeLists.txt
+++ b/example_7/CMakeLists.txt
@@ -27,6 +27,14 @@ set(CONTROLLER_INCLUDE_DEPENDS
   trajectory_msgs
 )
 
+# Specify the required version of ros2_control
+find_package(ros2_control 4.0.0)
+# Handle the case where the required version is not found
+if(NOT ros2_control_FOUND)
+  message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
+  "Are you using the correct branch of the ros2_control_demos repository?")
+endif()
+
 # find dependencies
 find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)

--- a/example_7/CMakeLists.txt
+++ b/example_7/CMakeLists.txt
@@ -28,9 +28,9 @@ set(CONTROLLER_INCLUDE_DEPENDS
 )
 
 # Specify the required version of ros2_control
-find_package(ros2_control 4.0.0)
+find_package(controller_manager 4.0.0)
 # Handle the case where the required version is not found
-if(NOT ros2_control_FOUND)
+if(NOT controller_manager_FOUND)
   message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
   "Are you using the correct branch of the ros2_control_demos repository?")
 endif()

--- a/example_8/CMakeLists.txt
+++ b/example_8/CMakeLists.txt
@@ -18,9 +18,9 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # Specify the required version of ros2_control
-find_package(ros2_control 4.0.0)
+find_package(controller_manager 4.0.0)
 # Handle the case where the required version is not found
-if(NOT ros2_control_FOUND)
+if(NOT controller_manager_FOUND)
   message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
   "Are you using the correct branch of the ros2_control_demos repository?")
 endif()

--- a/example_8/CMakeLists.txt
+++ b/example_8/CMakeLists.txt
@@ -17,6 +17,14 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   transmission_interface
 )
 
+# Specify the required version of ros2_control
+find_package(ros2_control 4.0.0)
+# Handle the case where the required version is not found
+if(NOT ros2_control_FOUND)
+  message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
+  "Are you using the correct branch of the ros2_control_demos repository?")
+endif()
+
 # find dependencies
 find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)

--- a/example_9/CMakeLists.txt
+++ b/example_9/CMakeLists.txt
@@ -16,6 +16,14 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   rclcpp_lifecycle
 )
 
+# Specify the required version of ros2_control
+find_package(ros2_control 4.0.0)
+# Handle the case where the required version is not found
+if(NOT ros2_control_FOUND)
+  message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
+  "Are you using the correct branch of the ros2_control_demos repository?")
+endif()
+
 # find dependencies
 find_package(backward_ros REQUIRED)
 find_package(ament_cmake REQUIRED)

--- a/example_9/CMakeLists.txt
+++ b/example_9/CMakeLists.txt
@@ -17,9 +17,9 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
 )
 
 # Specify the required version of ros2_control
-find_package(ros2_control 4.0.0)
+find_package(controller_manager 4.0.0)
 # Handle the case where the required version is not found
-if(NOT ros2_control_FOUND)
+if(NOT controller_manager_FOUND)
   message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
   "Are you using the correct branch of the ros2_control_demos repository?")
 endif()


### PR DESCRIPTION
We lately applied some breaking behavior changes of ros2_control to the demos (e.g., #502). The idea is now to check for the correct ros2_control version at compile-time

```
Starting >>> ros2_control_demo_example_1
--- stderr: ros2_control_demo_example_1                         
CMake Warning at CMakeLists.txt:20 (find_package):
  Could not find a configuration file for package "ros2_control" that is
  compatible with requested version "5.0.0".

  The following configuration files were considered but not accepted:

    /workspaces/ros2_rolling_ws/install/ros2_control/share/ros2_control/cmake/ros2_controlConfig.cmake, version: 4.13.0



CMake Error at CMakeLists.txt:23 (message):
  ros2_control version 5.0.0 or higher is required. Are you using the correct branch of the ros2_control_demos repository?
```

