### PR TITLE
Fix deprecation warning in paramater declaration

### DIFF
--- a/example_1/bringup/config/rrbot_forward_position_publisher.yaml
+++ b/example_1/bringup/config/rrbot_forward_position_publisher.yaml
@@ -6,6 +6,6 @@ publisher_forward_position_controller:
 
     goal_names: ["pos1", "pos2", "pos3", "pos4"]
     pos1: [0.785, 0.785]
-    pos2: [0, 0]
+    pos2: [0.0, 0.0]
     pos3: [-0.785, -0.785]
-    pos4: [0, 0]
+    pos4: [0.0, 0.0]


### PR DESCRIPTION
Updated `pos2` and `pos4` values from int to float as type implicitly mentioned in parameter declaration as `rclpy.Parameter.Type.DOUBLE_ARRAY` in `publisher_forward_position_controller` and `publisher_joint_trajectory_controller`.

Fixes: #1239 in ros2_controllers