### PR TITLE
Fix the publisher parameter type to `DOUBLE_ARRAY`

### DIFF
--- a/example_10/bringup/config/rrbot_forward_position_publisher.yaml
+++ b/example_10/bringup/config/rrbot_forward_position_publisher.yaml
@@ -6,6 +6,6 @@ publisher_forward_position_controller:
 
     goal_names: ["pos1", "pos2", "pos3", "pos4"]
     pos1: [0.785, 0.785]
-    pos2: [0, 0]
+    pos2: [0.0, 0.0]
     pos3: [-0.785, -0.785]
-    pos4: [0, 0]
+    pos4: [0.0, 0.0]

--- a/example_15/bringup/config/rrbot_namespace_forward_position_publisher.yaml
+++ b/example_15/bringup/config/rrbot_namespace_forward_position_publisher.yaml
@@ -7,6 +7,6 @@ publisher_forward_position_controller:
 
     goal_names: ["pos1", "pos2", "pos3", "pos4"]
     pos1: [0.785, 0.785]
-    pos2: [0, 0]
+    pos2: [0.0, 0.0]
     pos3: [-0.785, -0.785]
-    pos4: [0, 0]
+    pos4: [0.0, 0.0]

--- a/example_3/bringup/config/rrbot_forward_position_publisher.yaml
+++ b/example_3/bringup/config/rrbot_forward_position_publisher.yaml
@@ -6,6 +6,6 @@ publisher_forward_position_controller:
 
     goal_names: ["pos1", "pos2", "pos3", "pos4"]
     pos1: [0.785, 0.785]
-    pos2: [0, 0]
+    pos2: [0.0, 0.0]
     pos3: [-0.785, -0.785]
-    pos4: [0, 0]
+    pos4: [0.0, 0.0]

--- a/example_4/bringup/config/rrbot_forward_position_publisher.yaml
+++ b/example_4/bringup/config/rrbot_forward_position_publisher.yaml
@@ -6,6 +6,6 @@ publisher_forward_position_controller:
 
     goal_names: ["pos1", "pos2", "pos3", "pos4"]
     pos1: [0.785, 0.785]
-    pos2: [0, 0]
+    pos2: [0.0, 0.0]
     pos3: [-0.785, -0.785]
-    pos4: [0, 0]
+    pos4: [0.0, 0.0]

--- a/example_5/bringup/config/rrbot_forward_position_publisher.yaml
+++ b/example_5/bringup/config/rrbot_forward_position_publisher.yaml
@@ -6,6 +6,6 @@ publisher_forward_position_controller:
 
     goal_names: ["pos1", "pos2", "pos3", "pos4"]
     pos1: [0.785, 0.785]
-    pos2: [0, 0]
+    pos2: [0.0, 0.0]
     pos3: [-0.785, -0.785]
-    pos4: [0, 0]
+    pos4: [0.0, 0.0]

--- a/example_6/bringup/config/rrbot_forward_position_publisher.yaml
+++ b/example_6/bringup/config/rrbot_forward_position_publisher.yaml
@@ -6,6 +6,6 @@ publisher_forward_position_controller:
 
     goal_names: ["pos1", "pos2", "pos3", "pos4"]
     pos1: [0.785, 0.785]
-    pos2: [0, 0]
+    pos2: [0.0, 0.0]
     pos3: [-0.785, -0.785]
-    pos4: [0, 0]
+    pos4: [0.0, 0.0]

--- a/example_8/bringup/config/rrbot_forward_position_publisher.yaml
+++ b/example_8/bringup/config/rrbot_forward_position_publisher.yaml
@@ -6,6 +6,6 @@ publisher_forward_position_controller:
 
     goal_names: ["pos1", "pos2", "pos3", "pos4"]
     pos1: [0.785, 0.785]
-    pos2: [0, 0]
+    pos2: [0.0, 0.0]
     pos3: [-0.785, -0.785]
-    pos4: [0, 0]
+    pos4: [0.0, 0.0]

--- a/example_9/bringup/config/rrbot_forward_position_publisher.yaml
+++ b/example_9/bringup/config/rrbot_forward_position_publisher.yaml
@@ -6,6 +6,6 @@ publisher_forward_position_controller:
 
     goal_names: ["pos1", "pos2", "pos3", "pos4"]
     pos1: [0.785, 0.785]
-    pos2: [0, 0]
+    pos2: [0.0, 0.0]
     pos3: [-0.785, -0.785]
-    pos4: [0, 0]
+    pos4: [0.0, 0.0]


### PR DESCRIPTION
@fmauch found an issue with wrong parameter types, as we declared the type explicitly with https://github.com/ros-controls/ros2_controllers/pull/1280

```
[publisher_forward_position_controller-1] rclpy.exceptions.InvalidParameterTypeException: Trying to set parameter 'pos2' to '[0, 0]' of type 'INTEGER_ARRAY', expecting type 'DOUBLE_ARRAY': pos2
```