### PR TITLE
Use class methods for rclpy.init/shutdown

### DIFF
--- a/example_1/test/test_rrbot_launch.py
+++ b/example_1/test/test_rrbot_launch.py
@@ -41,7 +41,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -68,14 +67,19 @@ def generate_test_description():
 # This is our test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")
@@ -91,14 +95,19 @@ class TestFixture(unittest.TestCase):
 
 
 class TestFixtureCLI(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_main(self, proc_output):
 

--- a/example_1/test/test_rrbot_launch_cli_direct.py
+++ b/example_1/test/test_rrbot_launch_cli_direct.py
@@ -41,7 +41,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import check_controllers_running
 
 
@@ -62,14 +61,19 @@ def generate_test_description():
 
 
 class TestFixtureCliDirect(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_main(self, proc_output):
 

--- a/example_10/test/test_rrbot_launch.py
+++ b/example_10/test/test_rrbot_launch.py
@@ -39,7 +39,6 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -68,14 +67,19 @@ def generate_test_description():
 # This is our test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")

--- a/example_11/test/test_carlikebot_launch.py
+++ b/example_11/test/test_carlikebot_launch.py
@@ -40,7 +40,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -67,14 +66,19 @@ def generate_test_description():
 # This is our test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")

--- a/example_12/test/test_rrbot_launch.py
+++ b/example_12/test/test_rrbot_launch.py
@@ -41,7 +41,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -68,14 +67,19 @@ def generate_test_description():
 # This is our test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")
@@ -97,10 +101,9 @@ class TestFixture(unittest.TestCase):
 # This is our second test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixtureChained(unittest.TestCase):
-
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         rclpy.init()
-        self.node = Node("test_node")
         # Command to run the launch file
         command = [
             "ros2",
@@ -111,9 +114,15 @@ class TestFixtureChained(unittest.TestCase):
         # Execute the command
         subprocess.run(command)
 
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node("test_node")
+
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")

--- a/example_13/test/test_three_robots_launch.py
+++ b/example_13/test/test_three_robots_launch.py
@@ -41,7 +41,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -68,14 +67,19 @@ def generate_test_description():
 # This is our first test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")

--- a/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
+++ b/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
@@ -40,7 +40,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -67,14 +66,19 @@ def generate_test_description():
 # This is our test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")

--- a/example_15/test/test_multi_controller_manager_launch.py
+++ b/example_15/test/test_multi_controller_manager_launch.py
@@ -40,7 +40,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -67,14 +66,19 @@ def generate_test_description():
 # This is our test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")

--- a/example_15/test/test_rrbot_namespace_launch.py
+++ b/example_15/test/test_rrbot_namespace_launch.py
@@ -40,7 +40,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -67,14 +66,19 @@ def generate_test_description():
 # This is our test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")

--- a/example_2/test/test_diffbot_launch.py
+++ b/example_2/test/test_diffbot_launch.py
@@ -40,7 +40,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -67,14 +66,19 @@ def generate_test_description():
 # This is our test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")

--- a/example_3/test/test_rrbot_system_multi_interface_launch.py
+++ b/example_3/test/test_rrbot_system_multi_interface_launch.py
@@ -40,7 +40,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -67,14 +66,19 @@ def generate_test_description():
 # This is our test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")

--- a/example_4/test/test_rrbot_system_with_sensor_launch.py
+++ b/example_4/test/test_rrbot_system_with_sensor_launch.py
@@ -40,7 +40,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -67,14 +66,19 @@ def generate_test_description():
 # This is our test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")

--- a/example_5/test/test_rrbot_system_with_external_sensor_launch.py
+++ b/example_5/test/test_rrbot_system_with_external_sensor_launch.py
@@ -40,7 +40,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -67,14 +66,19 @@ def generate_test_description():
 # This is our test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")

--- a/example_6/test/test_rrbot_modular_actuators_launch.py
+++ b/example_6/test/test_rrbot_modular_actuators_launch.py
@@ -40,7 +40,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -67,14 +66,19 @@ def generate_test_description():
 # This is our test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")

--- a/example_7/test/test_r6bot_controller_launch.py
+++ b/example_7/test/test_r6bot_controller_launch.py
@@ -40,7 +40,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -67,14 +66,19 @@ def generate_test_description():
 # This is our test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")

--- a/example_8/test/test_rrbot_transmissions_system_position_only_launch.py
+++ b/example_8/test/test_rrbot_transmissions_system_position_only_launch.py
@@ -40,7 +40,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -67,14 +66,19 @@ def generate_test_description():
 # This is our test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")

--- a/example_9/test/test_rrbot_launch.py
+++ b/example_9/test/test_rrbot_launch.py
@@ -40,7 +40,6 @@ from launch_testing.actions import ReadyToTest
 
 # import launch_testing.markers
 import rclpy
-from rclpy.node import Node
 from ros2_control_demo_testing.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -67,14 +66,19 @@ def generate_test_description():
 # This is our test fixture. Each method is a test case.
 # These run alongside the processes specified in generate_test_description()
 class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
 
     def setUp(self):
-        rclpy.init()
-        self.node = Node("test_node")
+        self.node = rclpy.create_node("test_node")
 
     def tearDown(self):
         self.node.destroy_node()
-        rclpy.shutdown()
 
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")


### PR DESCRIPTION
I followed the guidelines of https://docs.ros.org/en/rolling/p/launch_testing/index.html

I was not aware that `setUp`/`tearDown` will be called for every test case.