### PR TITLE
Add missing shutdown call in test class

### DIFF
--- a/example_11/test/test_carlikebot_launch.py
+++ b/example_11/test/test_carlikebot_launch.py
@@ -107,6 +107,7 @@ class TestFixture(unittest.TestCase):
         old_topic = "/bicycle_steering_controller/tf_odometry"
         wait_for_topics = WaitForTopics([(old_topic, TFMessage)])
         assert not wait_for_topics.wait(), f"Topic '{old_topic}' found, but should be remapped!"
+        wait_for_topics.shutdown()
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore


### PR DESCRIPTION
According to the API description of `WaitForTopics` https://docs.ros.org/en/rolling/p/launch_testing_ros/launch_testing_ros.wait_for_topics.html

In the other occurrences we had that already.