### PR TITLE
Fix remapping arg in launch file and tests

### DIFF
--- a/example_11/CMakeLists.txt
+++ b/example_11/CMakeLists.txt
@@ -76,6 +76,7 @@ if(BUILD_TESTING)
   ament_add_pytest_test(example_11_urdf_xacro test/test_urdf_xacro.py)
   ament_add_pytest_test(view_example_11_launch test/test_view_robot_launch.py)
   ament_add_pytest_test(run_example_11_launch test/test_carlikebot_launch.py)
+  ament_add_pytest_test(run_example_11_launch_remapped test/test_carlikebot_launch_remapped.py)
 endif()
 
 ## EXPORTS

--- a/example_11/test/test_carlikebot_launch_remapped.py
+++ b/example_11/test/test_carlikebot_launch_remapped.py
@@ -60,7 +60,7 @@ def generate_test_description():
                 "launch/carlikebot.launch.py",
             )
         ),
-        launch_arguments={"gui": "false"}.items(),
+        launch_arguments={"gui": "false", "remap_odometry_tf": "true"}.items(),
     )
 
     return LaunchDescription([launch_include, ReadyToTest()])
@@ -102,10 +102,11 @@ class TestFixture(unittest.TestCase):
         )
 
     def test_remapped_topic(self):
-        # test if the remapping of the odometry topic is disabled
+        # we don't want to implement a tf lookup here
+        # so just check if the unmapped topic is not published
         old_topic = "/bicycle_steering_controller/tf_odometry"
         wait_for_topics = WaitForTopics([(old_topic, TFMessage)])
-        assert wait_for_topics.wait(), f"Topic '{old_topic}' not found!"
+        assert not wait_for_topics.wait(), f"Topic '{old_topic}' found, but should be remapped!"
         wait_for_topics.shutdown()
 
 


### PR DESCRIPTION
The remap_odometry_tf launch file argument was not cleaned up properly with #577 