### PR TITLE
Activate assertExitCodes for missing tests

### DIFF
--- a/example_1/test/test_rrbot_launch_cli_direct.py
+++ b/example_1/test/test_rrbot_launch_cli_direct.py
@@ -39,7 +39,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from controller_manager.test_utils import check_controllers_running
 
@@ -109,11 +109,10 @@ class TestFixtureCliDirect(unittest.TestCase):
         check_controllers_running(self.node, [cname], state="active")
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_11/test/test_carlikebot_launch_remapped.py
+++ b/example_11/test/test_carlikebot_launch_remapped.py
@@ -39,7 +39,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 from launch_testing_ros import WaitForTopics
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from controller_manager.test_utils import (
     check_controllers_running,
@@ -110,11 +110,10 @@ class TestFixture(unittest.TestCase):
         wait_for_topics.shutdown()
 
 
-# TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestDescriptionCraneShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestDescriptionCraneShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
+++ b/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
@@ -97,7 +97,7 @@ class TestFixture(unittest.TestCase):
 
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
-# see https://github.com/ros-controls/ros2_control_demos/issues/542
+# see https://github.com/ros-controls/ros2_control_demos/issues/721
 # @launch_testing.post_shutdown_test()
 # # These tests are run after the processes in generate_test_description() have shutdown.
 # class TestDescriptionCraneShutdown(unittest.TestCase):


### PR DESCRIPTION
Those were forgotten with #548 

example_14 still fails, see #721 