### PR TITLE
Print hardware component's rw_rate in example_1

### DIFF
--- a/example_1/hardware/rrbot.cpp
+++ b/example_1/hardware/rrbot.cpp
@@ -42,6 +42,7 @@ hardware_interface::CallbackReturn RRBotSystemPositionOnlyHardware::on_init(
   hw_start_sec_ = stod(info_.hardware_parameters["example_param_hw_start_duration_sec"]);
   hw_stop_sec_ = stod(info_.hardware_parameters["example_param_hw_stop_duration_sec"]);
   hw_slowdown_ = stod(info_.hardware_parameters["example_param_hw_slowdown"]);
+  RCLCPP_INFO(get_logger(), "Robot hardware_component update_rate is %dHz", info_.rw_rate);
   // END: This part here is for exemplary purposes - Please do not copy to your production code
 
   for (const hardware_interface::ComponentInfo & joint : info_.joints)


### PR DESCRIPTION
Was a simple test to see if rw_rate is set during on_init() call.