### PR TITLE
Fix broken links and text indentation in example_16 doc

### DIFF
--- a/example_16/README.md
+++ b/example_16/README.md
@@ -1,6 +1,5 @@
 # ros2_control_demo_example_16
 
-   *DiffBot*, or ''Differential Mobile Robot'', is a simple mobile base with differential drive.
-   The robot is basically a box moving according to differential drive kinematics.
+   *DiffBot*, or ''Differential Mobile Robot'', is a simple mobile base with differential drive. This example shows how to create chained controllers using diff_drive_controller and pid_controllers to control a differential drive robot.
 
 Find the documentation in [doc/userdoc.rst](doc/userdoc.rst) or on [control.ros.org](https://control.ros.org/master/doc/ros2_control_demos/example_16/doc/userdoc.html).

--- a/example_16/doc/userdoc.rst
+++ b/example_16/doc/userdoc.rst
@@ -8,7 +8,7 @@ DiffBot with Chained Controllers
 
 This example shows how to create chained controllers using diff_drive_controller and pid_controllers to control a differential drive robot. It extends *example_2*. If you haven't already, you can find the instructions for *example_2* in :ref:`ros2_control_demos_example_2_userdoc`. It is recommended to follow the steps given in that tutorial first before proceeding with this one.
 
-This example demonstrates controller chaining as described in :ref:`controller_chaining`. The control chain flows from the diff_drive_controller through two PID controllers to the DiffBot hardware. The diff_drive_controller converts desired robot twist into wheel velocity commands, which are then processed by the PID controllers to directly control the wheel velocities. Additionally, this example shows how to enable the feedforward mode for the PID controllers.
+This example demonstrates controller chaining as described in `controller_chaining <https://github.com/ros-controls/ros2_control/tree/{REPOS_FILE_BRANCH}/controller_manager/doc/controller_chaining.rst>`__. The control chain flows from the diff_drive_controller through two PID controllers to the DiffBot hardware. The diff_drive_controller converts desired robot twist into wheel velocity commands, which are then processed by the PID controllers to directly control the wheel velocities. Additionally, this example shows how to enable the feedforward mode for the PID controllers.
 
 Furthermore, this example shows how to use plotjuggler to visualize the controller states.
 
@@ -22,7 +22,7 @@ Tutorial steps
 
 1. To start *DiffBot* example open a terminal, source your ROS2-workspace and execute its launch file with
 
-   .. code-block:: shell
+  .. code-block:: shell
 
     ros2 launch ros2_control_demo_example_16 diffbot.launch.py
 
@@ -34,13 +34,13 @@ Tutorial steps
 
 2. Check controllers
 
-   .. code-block:: shell
+  .. code-block:: shell
 
     ros2 control list_controllers
 
   You should get
 
-   .. code-block:: shell
+  .. code-block:: shell
 
     joint_state_broadcaster          joint_state_broadcaster/JointStateBroadcaster  active
     diffbot_base_controller          diff_drive_controller/DiffDriveController      active
@@ -49,7 +49,7 @@ Tutorial steps
 
 3. Check the hardware interface loaded by opening another terminal and executing
 
-   .. code-block:: shell
+  .. code-block:: shell
 
     ros2 control list_hardware_interfaces
 
@@ -99,7 +99,7 @@ Tutorial steps
 
 6. Now we are ready to send a command to move the robot. Send a command to *Diff Drive Controller* by opening another terminal and executing
 
-   .. code-block:: shell
+  .. code-block:: shell
 
     ros2 topic pub --rate 10 /cmd_vel geometry_msgs/msg/TwistStamped "
     twist:
@@ -181,7 +181,7 @@ Before we proceed, we stop all previous steps from terminal and start from the b
 
 1. To start *DiffBot* example open a terminal, source your ROS2-workspace and execute its launch file with
 
-   .. code-block:: shell
+  .. code-block:: shell
 
     ros2 launch ros2_control_demo_example_16 diffbot.launch.py
 
@@ -189,13 +189,13 @@ Like before, if you can see an orange box in *RViz*, everything has started prop
 
 2. To start the plotjuggler with a provided layout file(plotjuggler.xml), open another terminal and run following command.
 
-   .. code-block:: shell
+  .. code-block:: shell
 
     ros2 run plotjuggler plotjuggler --layout $(ros2 pkg prefix ros2_control_demo_example_16 --share)/config/plotjuggler.xml
 
 After this, you will see a few dialogs popping up. For example:
 
-   .. code-block:: shell
+  .. code-block:: shell
 
     Start the previously used streaming plugin?
 
@@ -205,7 +205,7 @@ Click 'Yes' for the first dialog and 'OK" to the following two dialogs, then you
 
 3. To enable feedforward mode and published a command to move the robot, instead of doing these manually, we will use the demo_test.launch.py. Open another terminal and execute
 
-   .. code-block:: shell
+  .. code-block:: shell
 
     ros2 launch ros2_control_demo_example_16 demo_test.launch.py
 
@@ -217,7 +217,7 @@ Click 'Yes' for the first dialog and 'OK" to the following two dialogs, then you
 
 5. Change the ``gains`` in the ``diffbot_chained_controllers.yaml`` file with some different values, repeat above steps and observe its effect to the pid_controller commands. For example, to change the ``feedforward_gain`` of the right wheel to 0.50, you can use the following command:
 
-   .. code-block:: shell
+  .. code-block:: shell
 
     ros2 param set /pid_controller_right_wheel_joint gains.right_wheel_joint.feedforward_gain 0.50
 
@@ -226,7 +226,7 @@ Files used for this demo
 --------------------------
 
 * Launch file: `diffbot.launch.py <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_16/bringup/launch/diffbot.launch.py>`__
-* Controllers yaml: `diffbot_chained_controllers.yaml <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_16/config/diffbot_chained_controllers.yaml>`__
+* Controllers yaml: `diffbot_chained_controllers.yaml <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_16/bringup/config/diffbot_chained_controllers.yaml>`__
 * URDF file: `diffbot.urdf.xacro <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_16/description/urdf/diffbot.urdf.xacro>`__
 
   * Description: `diffbot_description.urdf.xacro <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/ros2_control_demo_description/diffbot/urdf/diffbot_description.urdf.xacro>`__

--- a/example_16/doc/userdoc.rst
+++ b/example_16/doc/userdoc.rst
@@ -8,7 +8,7 @@ DiffBot with Chained Controllers
 
 This example shows how to create chained controllers using diff_drive_controller and pid_controllers to control a differential drive robot. It extends *example_2*. If you haven't already, you can find the instructions for *example_2* in :ref:`ros2_control_demos_example_2_userdoc`. It is recommended to follow the steps given in that tutorial first before proceeding with this one.
 
-This example demonstrates controller chaining as described in `controller_chaining <https://github.com/ros-controls/ros2_control/tree/{REPOS_FILE_BRANCH}/controller_manager/doc/controller_chaining.rst>`__. The control chain flows from the diff_drive_controller through two PID controllers to the DiffBot hardware. The diff_drive_controller converts desired robot twist into wheel velocity commands, which are then processed by the PID controllers to directly control the wheel velocities. Additionally, this example shows how to enable the feedforward mode for the PID controllers.
+This example demonstrates controller chaining as described in :ref:`controller_chaining`. The control chain flows from the diff_drive_controller through two PID controllers to the DiffBot hardware. The diff_drive_controller converts desired robot twist into wheel velocity commands, which are then processed by the PID controllers to directly control the wheel velocities. Additionally, this example shows how to enable the feedforward mode for the PID controllers.
 
 Furthermore, this example shows how to use plotjuggler to visualize the controller states.
 
@@ -185,7 +185,7 @@ Before we proceed, we stop all previous steps from terminal and start from the b
 
     ros2 launch ros2_control_demo_example_16 diffbot.launch.py
 
-Like before, if you can see an orange box in *RViz*, everything has started properly.
+  Like before, if you can see an orange box in *RViz*, everything has started properly.
 
 2. To start the plotjuggler with a provided layout file(plotjuggler.xml), open another terminal and run following command.
 
@@ -193,7 +193,7 @@ Like before, if you can see an orange box in *RViz*, everything has started prop
 
     ros2 run plotjuggler plotjuggler --layout $(ros2 pkg prefix ros2_control_demo_example_16 --share)/config/plotjuggler.xml
 
-After this, you will see a few dialogs popping up. For example:
+  After this, you will see a few dialogs popping up. For example:
 
   .. code-block:: shell
 
@@ -201,7 +201,7 @@ After this, you will see a few dialogs popping up. For example:
 
     ROS2 Topic Subscriber
 
-Click 'Yes' for the first dialog and 'OK" to the following two dialogs, then you will see the plotjuggler window.
+  Click 'Yes' for the first dialog and 'OK" to the following two dialogs, then you will see the plotjuggler window.
 
 3. To enable feedforward mode and published a command to move the robot, instead of doing these manually, we will use the demo_test.launch.py. Open another terminal and execute
 


### PR DESCRIPTION
Fix https://github.com/ros-controls/ros2_control_demos/issues/742 and a text indentation issue for Tutorial [steps 2](https://control.ros.org/rolling/doc/ros2_control_demos/example_16/doc/userdoc.html#tutorial-steps). 

- Changes have been tested locally by following instructions from https://github.com/ros-controls/control.ros.org?tab=readme-ov-file#build-instructions. 