### PR TITLE
[example_9] Add gazebo bridge node for clock sync-ing

### DIFF
--- a/example_9/bringup/config/rrbot_controllers.yaml
+++ b/example_9/bringup/config/rrbot_controllers.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 10  # Hz
+    update_rate: 1000  # Hz
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster

--- a/example_9/bringup/launch/rrbot_gazebo.launch.py
+++ b/example_9/bringup/launch/rrbot_gazebo.launch.py
@@ -44,6 +44,14 @@ def generate_launch_description():
         launch_arguments={"gz_args": " -r -v 3 empty.sdf"}.items(),
     )
 
+    # Gazebo bridge
+    gazebo_bridge = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        arguments=["/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock"],
+        output="screen",
+    )
+
     gz_spawn_entity = Node(
         package="ros_gz_sim",
         executable="create",
@@ -113,6 +121,7 @@ def generate_launch_description():
 
     nodes = [
         gazebo,
+        gazebo_bridge,
         node_robot_state_publisher,
         gz_spawn_entity,
         joint_state_broadcaster_spawner,

--- a/example_9/description/gazebo/rrbot.gazebo.xacro
+++ b/example_9/description/gazebo/rrbot.gazebo.xacro
@@ -16,21 +16,36 @@ https://github.com/ros-simulation/gazebo_ros_demos/blob/kinetic-devel/rrbot_desc
 
     <!-- Link1 -->
     <gazebo reference="${prefix}base_link">
-      <material>Gazebo/Orange</material>
+      <material>
+        <script>
+          <uri>file://media/materials/scripts/gazebo.material</uri>
+          <name>Gazebo/Orange</name>
+        </script>
+      </material>
     </gazebo>
 
     <!-- Link2 -->
     <gazebo reference="${prefix}link1">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/Yellow</material>
+      <material>
+        <script>
+          <uri>file://media/materials/scripts/gazebo.material</uri>
+          <name>Gazebo/Yellow</name>
+        </script>
+      </material>
     </gazebo>
 
     <!-- Link3 -->
     <gazebo reference="${prefix}link2">
       <mu1>0.2</mu1>
       <mu2>0.2</mu2>
-      <material>Gazebo/Orange</material>
+      <material>
+        <script>
+          <uri>file://media/materials/scripts/gazebo.material</uri>
+          <name>Gazebo/Yellow</name>
+        </script>
+      </material>
     </gazebo>
 
   </xacro:macro>

--- a/example_9/package.xml
+++ b/example_9/package.xml
@@ -26,6 +26,7 @@
 
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
+  <exec_depend>ros_gz_bridge</exec_depend>
   <exec_depend>ros_gz_sim</exec_depend>
   <exec_depend>gz_ros2_control</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>


### PR DESCRIPTION
The main change is to add a Gazebo [bridge node](https://github.com/gazebosim/ros_gz/blob/ros2/ros_gz_bridge/README.md) to fix following Gazebo runtime error after launching the example. The error will cause Gazebo to be terminated. 

```
ros2 launch ros2_control_demo_example_9 rrbot_gazebo.launch.py gui:=true

# logs 
[gazebo-1] terminate called after throwing an instance of 'std::runtime_error'
[gazebo-1]   what():  can't compare times with different time sources
[gazebo-1] Stack trace (most recent call last) in thread 270397:
[gazebo-1] #14   Object "[0xffffffffffffffff]", at 0xffffffffffffffff, in 
[gazebo-1] #13   Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7d5de3d29c3b, in 
[gazebo-1] #12   Object "/lib/x86_64-linux-gnu/libc.so.6", at 0x7d5de3c9caa3, in 
[gazebo-1] #11   Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7d5dde2ecdb3, in 
[gazebo-1] #10   Object "/opt/ros/jazzy/opt/gz_sim_vendor/lib/libgz-sim8.so.8", at 0x7d5ddd34ed45, in 
[gazebo-1] #9    Object "/home/juliajia/ros2_control_ws/install/gz_ros2_control/lib/libgz_ros2_control-system.so", at 0x7d5daa9717c5, in gz_ros2_control::GazeboSimROS2ControlPlugin::PostUpdate(gz::sim::v8::UpdateInfo const&, gz::sim::v8::EntityComponentManager const&)
[gazebo-1] #8    Object "/home/juliajia/ros2_control_ws/install/controller_manager/lib/libcontroller_manager.so", at 0x7d5daa486561, in controller_manager::ControllerManager::update(rclcpp::Time const&, rclcpp::Duration const&)
[gazebo-1] #7    Object "/opt/ros/jazzy/lib/librclcpp.so", at 0x7d5da96e2a90, in 
[gazebo-1] #6    Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7d5dde2bb390, in __cxa_throw
[gazebo-1] #5    Object "/lib/x86_64-linux-gnu/libstdc++.so.6", at 0x7d5dde2a5a54, in std::terminate()
```

The additional changes are to fix following warnings reported. 
- One is related to the color (e.g. Gazebo/Orange). Change made based on https://gazebosim.org/api/sim/8/migrationsdf.html#:~:text=Materials.
```
[gazebo-1] [Wrn] [SdfEntityCreator.cc:949] Using an internal gazebo.material to parse Gazebo/Orange
[gazebo-1] [Wrn] [SdfEntityCreator.cc:933] Gazebo does not support Ogre material scripts. See https://gazebosim.org/api/sim/8/migrationsdf.html#:~:text=Materials for details.
```

- The mismatched update rate from controller manager and Gazebo sim. Increased the update_rate for controller manager. 
```
[gazebo-1] [WARN] [1743040617.401316543] [gz_ros_control]:  Desired controller update period (0.1 s) is slower than the gazebo simulation period (0.001 s).
```
There are more warnings that appear unrelated to the example based on my initial check. I am open to change if it's not the case. For example 
```
[gazebo-1] [GUI] [Wrn] [Application.cc:908] [QT] file::/WorldStats/WorldStats.qml:53:3: QML RowLayout: Binding loop detected for property "x"

[gazebo-1] Warning [parser_urdf.cc:1220] Attribute value string not set
```
