### PR TITLE
Test also for the inactive controller

### DIFF
--- a/example_13/test/test_three_robots_launch.py
+++ b/example_13/test/test_three_robots_launch.py
@@ -95,8 +95,15 @@ class TestFixture(unittest.TestCase):
             "rrbot_with_sensor_joint_state_broadcaster",
             "rrbot_with_sensor_fts_broadcaster",
         ]
+        check_controllers_running(self.node, cnames, "", "active")
+        cnames = [
+            "rrbot_with_sensor_position_controller",
+            "threedofbot_joint_state_broadcaster",
+            "threedofbot_position_controller",
+            "threedofbot_pid_gain_controller",
+        ]
+        check_controllers_running(self.node, cnames, "", "inactive")
 
-        check_controllers_running(self.node, cnames)
         check_if_js_published(
             "/joint_states",
             [

--- a/example_15/test/test_multi_controller_manager_launch.py
+++ b/example_15/test/test_multi_controller_manager_launch.py
@@ -83,14 +83,20 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")
 
-    def test_controller_running_cm1(self, proc_output):
+    def test_controller_running(self, proc_output):
 
         cnames = [
             "forward_position_controller",
             "joint_state_broadcaster",
         ]
-        check_controllers_running(self.node, cnames, "/rrbot_1")
-        check_controllers_running(self.node, cnames, "/rrbot_2")
+        check_controllers_running(self.node, cnames, "/rrbot_1", "active")
+        check_controllers_running(self.node, cnames, "/rrbot_2", "active")
+
+        cnames = [
+            "position_trajectory_controller",
+        ]
+        check_controllers_running(self.node, cnames, "/rrbot_1", "inactive")
+        check_controllers_running(self.node, cnames, "/rrbot_2", "inactive")
 
     def test_check_if_msgs_published(self):
         check_if_js_published("/rrbot_1/joint_states", ["rrbot_1_joint1", "rrbot_1_joint2"])

--- a/example_15/test/test_rrbot_namespace_launch.py
+++ b/example_15/test/test_rrbot_namespace_launch.py
@@ -89,8 +89,11 @@ class TestFixture(unittest.TestCase):
             "forward_position_controller",
             "joint_state_broadcaster",
         ]
+        check_controllers_running(self.node, cnames, "/rrbot", "active")
 
-        check_controllers_running(self.node, cnames, "/rrbot")
+        check_controllers_running(
+            self.node, ["position_trajectory_controller"], "/rrbot", "inactive"
+        )
 
     def test_check_if_msgs_published(self):
         check_if_js_published("/rrbot/joint_states", ["joint1", "joint2"])


### PR DESCRIPTION
fixes https://github.com/ros-controls/ros2_control_ci/issues/287

the test finished sending SIGINTs to all processes, but the spawner for the inactive controller was not finished yet. If we check also for the inactive controller to be spawend, this should not happen anymore.