### PR TITLE
[Example 5] Cast to double in the force torque HW interface

### DIFF
--- a/example_5/hardware/external_rrbot_force_torque_sensor.cpp
+++ b/example_5/hardware/external_rrbot_force_torque_sensor.cpp
@@ -98,7 +98,7 @@ hardware_interface::return_type ExternalRRBotForceTorqueSensorHardware::read(
     // Simulate RRBot's sensor data
     unsigned int seed = static_cast<unsigned int>(time(NULL)) + i++;
     set_state(
-      name, static_cast<float>(rand_r(&seed)) / (static_cast<float>(RAND_MAX / hw_sensor_change_)));
+      name, static_cast<double>(rand_r(&seed)) / (static_cast<double>(RAND_MAX / hw_sensor_change_)));
 
     ss << std::endl << "\t" << get_state(name) << " for sensor '" << name << "'";
   }

--- a/example_5/hardware/external_rrbot_force_torque_sensor.cpp
+++ b/example_5/hardware/external_rrbot_force_torque_sensor.cpp
@@ -98,7 +98,8 @@ hardware_interface::return_type ExternalRRBotForceTorqueSensorHardware::read(
     // Simulate RRBot's sensor data
     unsigned int seed = static_cast<unsigned int>(time(NULL)) + i++;
     set_state(
-      name, static_cast<double>(rand_r(&seed)) / (static_cast<double>(RAND_MAX / hw_sensor_change_)));
+      name,
+      static_cast<double>(rand_r(&seed)) / (static_cast<double>(RAND_MAX / hw_sensor_change_)));
 
     ss << std::endl << "\t" << get_state(name) << " for sensor '" << name << "'";
   }


### PR DESCRIPTION
This is needed after we merged the latest changes for boolean suuport. Floats are not casted anymore, it will only caused compilation error

https://github.com/ros-controls/ros2_control/actions/runs/14365884755/job/40278566870