### PR TITLE
Use joint_state_interfaces in RRBotSensorPositionFeedback

### DIFF
--- a/example_14/hardware/rrbot_sensor_for_position_feedback.cpp
+++ b/example_14/hardware/rrbot_sensor_for_position_feedback.cpp
@@ -175,7 +175,7 @@ hardware_interface::CallbackReturn RRBotSensorPositionFeedback::on_configure(
 
   // set some default values for joints
   // reset values always when configuring hardware
-  for (const auto & [name, descr] : sensor_state_interfaces_)
+  for (const auto & [name, descr] : joint_state_interfaces_)
   {
     set_state(name, 0.0);
   }


### PR DESCRIPTION
I introduced a bug with #653: The state interfaces are joints, and not sensors -> the joints haven't been set to zero -> the integration step starts from NaN and stays there.