### PR TITLE
Update cmake_minimum_required VERSION

### DIFF
--- a/ros2_control_demo_description/CMakeLists.txt
+++ b/ros2_control_demo_description/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(ros2_control_demo_description)
 
 find_package(ament_cmake REQUIRED)

--- a/ros2_control_demos/CMakeLists.txt
+++ b/ros2_control_demos/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(ros2_control_demos)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
CMake < 3.10 is deprecated on some platforms https://github.com/ros-controls/ros2_control_cmake/pull/8#pullrequestreview-2904365381