### PR TITLE
Fix thread stopping of example_14

### DIFF
--- a/example_14/description/ros2_control/rrbot_modular_actuators_without_feedback_sensors_for_position_feedback.ros2_control.xacro
+++ b/example_14/description/ros2_control/rrbot_modular_actuators_without_feedback_sensors_for_position_feedback.ros2_control.xacro
@@ -6,7 +6,7 @@
 
     <!-- NOTE generally is the order of hardware definition not relevant. But in this case the
     sensors are listening on sockets to which the actuators are connecting. Therefore, the sensors
-    has to be initialized and configured first. Note: configuration will be done in reverse order. -->
+    has to be initialized and configured first. Configuration will be done in reverse order. -->
 
     <ros2_control name="RRBotModularJoint1" type="actuator">
       <hardware>

--- a/example_14/description/ros2_control/rrbot_modular_actuators_without_feedback_sensors_for_position_feedback.ros2_control.xacro
+++ b/example_14/description/ros2_control/rrbot_modular_actuators_without_feedback_sensors_for_position_feedback.ros2_control.xacro
@@ -6,38 +6,13 @@
 
     <!-- NOTE generally is the order of hardware definition not relevant. But in this case the
     sensors are listening on sockets to which the actuators are connecting. Therefore, the sensors
-    has to be initialized and started first. -->
-
-    <ros2_control name="RRBotModularPositionSensorJoint1" type="sensor">
-      <hardware>
-        <plugin>ros2_control_demo_example_14/RRBotSensorPositionFeedback</plugin>
-        <param name="example_param_hw_start_duration_sec">1.0</param>
-        <param name="example_param_hw_stop_duration_sec">2.0</param>
-        <param name="example_param_hw_slowdown">${slowdown}</param>
-        <param name="example_param_socket_port">23286</param>
-      </hardware>
-      <joint name="joint1">
-        <state_interface name="position"/>
-      </joint>
-    </ros2_control>
-    <ros2_control name="RRBotModularPositionSensorJoint2" type="sensor">
-      <hardware>
-        <plugin>ros2_control_demo_example_14/RRBotSensorPositionFeedback</plugin>
-        <param name="example_param_hw_start_duration_sec">1.0</param>
-        <param name="example_param_hw_stop_duration_sec">2.0</param>
-        <param name="example_param_hw_slowdown">${slowdown}</param>
-        <param name="example_param_socket_port">23287</param>
-      </hardware>
-      <joint name="joint2">
-        <state_interface name="position"/>
-      </joint>
-    </ros2_control>
+    has to be initialized and configured first. Note: configuration will be done in reverse order. -->
 
     <ros2_control name="RRBotModularJoint1" type="actuator">
       <hardware>
         <plugin>ros2_control_demo_example_14/RRBotActuatorWithoutFeedback</plugin>
         <param name="example_param_hw_start_duration_sec">2.0</param>
-        <param name="example_param_hw_stop_duration_sec">3.0</param>
+        <param name="example_param_hw_stop_duration_sec">1.0</param>
         <param name="example_param_socket_port">23286</param>
       </hardware>
       <joint name="joint1">
@@ -51,7 +26,7 @@
       <hardware>
         <plugin>ros2_control_demo_example_14/RRBotActuatorWithoutFeedback</plugin>
         <param name="example_param_hw_start_duration_sec">2.0</param>
-        <param name="example_param_hw_stop_duration_sec">3.0</param>
+        <param name="example_param_hw_stop_duration_sec">1.0</param>
         <param name="example_param_socket_port">23287</param>
       </hardware>
       <joint name="joint2">
@@ -60,7 +35,32 @@
           <param name="max">1</param>
         </command_interface>
       </joint>
-      </ros2_control>
+    </ros2_control>
+
+    <ros2_control name="RRBotModularPositionSensorJoint1" type="sensor">
+      <hardware>
+        <plugin>ros2_control_demo_example_14/RRBotSensorPositionFeedback</plugin>
+        <param name="example_param_hw_start_duration_sec">1.0</param>
+        <param name="example_param_hw_stop_duration_sec">0.0</param>
+        <param name="example_param_hw_slowdown">${slowdown}</param>
+        <param name="example_param_socket_port">23286</param>
+      </hardware>
+      <joint name="joint1">
+        <state_interface name="position"/>
+      </joint>
+    </ros2_control>
+    <ros2_control name="RRBotModularPositionSensorJoint2" type="sensor">
+      <hardware>
+        <plugin>ros2_control_demo_example_14/RRBotSensorPositionFeedback</plugin>
+        <param name="example_param_hw_start_duration_sec">1.0</param>
+        <param name="example_param_hw_stop_duration_sec">0.0</param>
+        <param name="example_param_hw_slowdown">${slowdown}</param>
+        <param name="example_param_socket_port">23287</param>
+      </hardware>
+      <joint name="joint2">
+        <state_interface name="position"/>
+      </joint>
+    </ros2_control>
 
   </xacro:macro>
 

--- a/example_14/hardware/include/ros2_control_demo_example_14/rrbot_actuator_without_feedback.hpp
+++ b/example_14/hardware/include/ros2_control_demo_example_14/rrbot_actuator_without_feedback.hpp
@@ -50,7 +50,7 @@ public:
   hardware_interface::CallbackReturn on_deactivate(
     const rclcpp_lifecycle::State & previous_state) override;
 
-  hardware_interface::CallbackReturn on_shutdown(
+  hardware_interface::CallbackReturn on_cleanup(
     const rclcpp_lifecycle::State & previous_state) override;
 
   hardware_interface::return_type read(

--- a/example_14/hardware/include/ros2_control_demo_example_14/rrbot_actuator_without_feedback.hpp
+++ b/example_14/hardware/include/ros2_control_demo_example_14/rrbot_actuator_without_feedback.hpp
@@ -53,6 +53,9 @@ public:
   hardware_interface::CallbackReturn on_cleanup(
     const rclcpp_lifecycle::State & previous_state) override;
 
+  hardware_interface::CallbackReturn on_shutdown(
+    const rclcpp_lifecycle::State & previous_state) override;
+
   hardware_interface::return_type read(
     const rclcpp::Time & time, const rclcpp::Duration & period) override;
 

--- a/example_14/hardware/include/ros2_control_demo_example_14/rrbot_sensor_for_position_feedback.hpp
+++ b/example_14/hardware/include/ros2_control_demo_example_14/rrbot_sensor_for_position_feedback.hpp
@@ -55,7 +55,7 @@ public:
   hardware_interface::CallbackReturn on_deactivate(
     const rclcpp_lifecycle::State & previous_state) override;
 
-  hardware_interface::CallbackReturn on_shutdown(
+  hardware_interface::CallbackReturn on_cleanup(
     const rclcpp_lifecycle::State & previous_state) override;
 
   hardware_interface::return_type read(

--- a/example_14/hardware/include/ros2_control_demo_example_14/rrbot_sensor_for_position_feedback.hpp
+++ b/example_14/hardware/include/ros2_control_demo_example_14/rrbot_sensor_for_position_feedback.hpp
@@ -58,6 +58,9 @@ public:
   hardware_interface::CallbackReturn on_cleanup(
     const rclcpp_lifecycle::State & previous_state) override;
 
+  hardware_interface::CallbackReturn on_shutdown(
+    const rclcpp_lifecycle::State & previous_state) override;
+
   hardware_interface::return_type read(
     const rclcpp::Time & time, const rclcpp::Duration & period) override;
 

--- a/example_14/hardware/include/ros2_control_demo_example_14/rrbot_sensor_for_position_feedback.hpp
+++ b/example_14/hardware/include/ros2_control_demo_example_14/rrbot_sensor_for_position_feedback.hpp
@@ -22,6 +22,7 @@
 #include <netinet/in.h>
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -77,9 +78,12 @@ private:
 
   // Sync incoming commands between threads
   std::atomic<double> rt_incoming_data_;
+  std::atomic<bool> receive_data_;
 
   // Create timer to checking incoming data on socket
   std::thread incoming_data_thread_;
+  std::mutex mtx;
+  std::condition_variable cv;
 
   // Fake "mechanical connection" between actuator and sensor using sockets
   struct sockaddr_in address_;

--- a/example_14/hardware/rrbot_actuator_without_feedback.cpp
+++ b/example_14/hardware/rrbot_actuator_without_feedback.cpp
@@ -148,7 +148,7 @@ hardware_interface::CallbackReturn RRBotActuatorWithoutFeedback::on_configure(
   return hardware_interface::CallbackReturn::SUCCESS;
 }
 
-hardware_interface::CallbackReturn RRBotActuatorWithoutFeedback::on_shutdown(
+hardware_interface::CallbackReturn RRBotActuatorWithoutFeedback::on_cleanup(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
   shutdown(sock_, SHUT_RDWR);  // shutdown socket

--- a/example_14/hardware/rrbot_actuator_without_feedback.cpp
+++ b/example_14/hardware/rrbot_actuator_without_feedback.cpp
@@ -89,7 +89,17 @@ hardware_interface::CallbackReturn RRBotActuatorWithoutFeedback::on_init(
     reinterpret_cast<char *>(server->h_addr), reinterpret_cast<char *>(&address_.sin_addr.s_addr),
     server->h_length);
   address_.sin_port = htons(socket_port_);
+  // END: This part here is for exemplary purposes - Please do not copy to your production code
 
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn RRBotActuatorWithoutFeedback::on_configure(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  RCLCPP_INFO(get_logger(), "Configuring ...please wait...");
+
+  // BEGIN: This part here is for exemplary purposes - Please do not copy to your production code
   const int max_retries = 5;
   const int initial_delay_ms = 1000;  // Initial delay of 1 second
 
@@ -128,13 +138,6 @@ hardware_interface::CallbackReturn RRBotActuatorWithoutFeedback::on_init(
     RCLCPP_INFO(get_logger(), "Successfully connected to port %d.", socket_port_);
   }
   // END: This part here is for exemplary purposes - Please do not copy to your production code
-  return hardware_interface::CallbackReturn::SUCCESS;
-}
-
-hardware_interface::CallbackReturn RRBotActuatorWithoutFeedback::on_configure(
-  const rclcpp_lifecycle::State & /*previous_state*/)
-{
-  RCLCPP_INFO(get_logger(), "Configuring ...please wait...");
 
   // reset values always when configuring hardware
   for (const auto & [name, descr] : joint_command_interfaces_)

--- a/example_14/hardware/rrbot_actuator_without_feedback.cpp
+++ b/example_14/hardware/rrbot_actuator_without_feedback.cpp
@@ -156,6 +156,12 @@ hardware_interface::CallbackReturn RRBotActuatorWithoutFeedback::on_cleanup(
   return hardware_interface::CallbackReturn::SUCCESS;
 }
 
+hardware_interface::CallbackReturn RRBotActuatorWithoutFeedback::on_shutdown(
+  const rclcpp_lifecycle::State & previous_state)
+{
+  return on_cleanup(previous_state);
+}
+
 hardware_interface::CallbackReturn RRBotActuatorWithoutFeedback::on_activate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {

--- a/example_14/hardware/rrbot_sensor_for_position_feedback.cpp
+++ b/example_14/hardware/rrbot_sensor_for_position_feedback.cpp
@@ -223,6 +223,12 @@ hardware_interface::CallbackReturn RRBotSensorPositionFeedback::on_cleanup(
   return hardware_interface::CallbackReturn::SUCCESS;
 }
 
+hardware_interface::CallbackReturn RRBotSensorPositionFeedback::on_shutdown(
+  const rclcpp_lifecycle::State & previous_state)
+{
+  return on_cleanup(previous_state);
+}
+
 hardware_interface::CallbackReturn RRBotSensorPositionFeedback::on_activate(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {

--- a/example_14/hardware/rrbot_sensor_for_position_feedback.cpp
+++ b/example_14/hardware/rrbot_sensor_for_position_feedback.cpp
@@ -106,8 +106,20 @@ hardware_interface::CallbackReturn RRBotSensorPositionFeedback::on_init(
     return hardware_interface::CallbackReturn::ERROR;
   }
 
-  // Storage and Thread for incoming data
+  // Storage for incoming data
   rt_incoming_data_ = std::numeric_limits<double>::quiet_NaN();
+
+  return hardware_interface::CallbackReturn::SUCCESS;
+}
+
+hardware_interface::CallbackReturn RRBotSensorPositionFeedback::on_configure(
+  const rclcpp_lifecycle::State & /*previous_state*/)
+{
+  RCLCPP_INFO(get_logger(), "Configuring ...please wait...");
+
+  // START: This part here is for exemplary purposes - Please do not copy to your production code
+  // Thread for incoming data
+  receive_data_ = true;
   incoming_data_thread_ = std::thread(
     [this]()
     {
@@ -145,32 +157,35 @@ hardware_interface::CallbackReturn RRBotSensorPositionFeedback::on_init(
       RCLCPP_INFO(get_logger(), "Receiving data");
       while (rclcpp::ok())
       {
+        {
+          std::unique_lock<std::mutex> lock(mtx);
+          bool should_stop = cv.wait_for(
+            lock, std::chrono::nanoseconds(1000000000 / incoming_data_read_rate),
+            [this]() { return !receive_data_.load(); });
+
+          if (should_stop)
+          {
+            break;
+          }
+        }
+
         if (recv(sock_, buffer, reading_size_bytes, 0) > 0)
         {
-          RCLCPP_DEBUG(get_logger(), "Read form buffer sockets data: '%s'", buffer);
-
+          RCLCPP_DEBUG(get_logger(), "Read from buffer sockets data: '%s'", buffer);
           rt_incoming_data_ = hardware_interface::stod(buffer);
         }
         else
         {
-          RCLCPP_INFO(get_logger(), "Data not yet received from socket.");
+          RCLCPP_INFO_THROTTLE(
+            get_logger(), *this->get_clock(), 500, "Data not yet received from socket.");
           rt_incoming_data_ = std::numeric_limits<double>::quiet_NaN();
         }
 
         bzero(buffer, reading_size_bytes);
-        std::this_thread::sleep_for(std::chrono::nanoseconds(1000000000 / incoming_data_read_rate));
       }
       return hardware_interface::CallbackReturn::SUCCESS;
     });
   // END: This part here is for exemplary purposes - Please do not copy to your production code
-
-  return hardware_interface::CallbackReturn::SUCCESS;
-}
-
-hardware_interface::CallbackReturn RRBotSensorPositionFeedback::on_configure(
-  const rclcpp_lifecycle::State & /*previous_state*/)
-{
-  RCLCPP_INFO(get_logger(), "Configuring ...please wait...");
 
   // set some default values for joints
   // reset values always when configuring hardware
@@ -190,9 +205,20 @@ hardware_interface::CallbackReturn RRBotSensorPositionFeedback::on_configure(
 hardware_interface::CallbackReturn RRBotSensorPositionFeedback::on_shutdown(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
-  incoming_data_thread_.join();      // stop reading thread
-  shutdown(sock_, SHUT_RDWR);        // shutdown socket
-  shutdown(obj_socket_, SHUT_RDWR);  // shutdown socket
+  // To stop the thread
+  {
+    std::lock_guard<std::mutex> lock(mtx);
+    receive_data_ = false;
+    shutdown(sock_, SHUT_RDWR);        // shutdown socket
+    shutdown(obj_socket_, SHUT_RDWR);  // shutdown socket
+  }
+  cv.notify_all();
+
+  // stop reading thread
+  if (incoming_data_thread_.joinable())
+  {
+    incoming_data_thread_.join();
+  }
 
   return hardware_interface::CallbackReturn::SUCCESS;
 }

--- a/example_14/hardware/rrbot_sensor_for_position_feedback.cpp
+++ b/example_14/hardware/rrbot_sensor_for_position_feedback.cpp
@@ -202,7 +202,7 @@ hardware_interface::CallbackReturn RRBotSensorPositionFeedback::on_configure(
   return hardware_interface::CallbackReturn::SUCCESS;
 }
 
-hardware_interface::CallbackReturn RRBotSensorPositionFeedback::on_shutdown(
+hardware_interface::CallbackReturn RRBotSensorPositionFeedback::on_cleanup(
   const rclcpp_lifecycle::State & /*previous_state*/)
 {
   // To stop the thread

--- a/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
+++ b/example_14/test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py
@@ -38,7 +38,7 @@ from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_testing.actions import ReadyToTest
 
-# import launch_testing.markers
+import launch_testing.markers
 import rclpy
 from controller_manager.test_utils import (
     check_controllers_running,
@@ -98,10 +98,10 @@ class TestFixture(unittest.TestCase):
 
 # TODO(anyone): enable this if shutdown of ros2_control_node does not fail anymore
 # see https://github.com/ros-controls/ros2_control_demos/issues/721
-# @launch_testing.post_shutdown_test()
-# # These tests are run after the processes in generate_test_description() have shutdown.
-# class TestShutdown(unittest.TestCase):
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestShutdown(unittest.TestCase):
 
-#     def test_exit_codes(self, proc_info):
-#         """Check if the processes exited normally."""
-#         launch_testing.asserts.assertExitCodes(proc_info)
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)


### PR DESCRIPTION
Socket connection is now only active in inactive and active state (connection in `on_configure`, graceful stopping in `on_cleanup`).

Closes #721 

Example could be improved by using hardware lifecycling. 