### PR TITLE
Throttle the log output

### DIFF
--- a/example_3/hardware/rrbot_system_multi_interface.cpp
+++ b/example_3/hardware/rrbot_system_multi_interface.cpp
@@ -241,7 +241,8 @@ hardware_interface::return_type RRBotSystemMultiInterfaceHardware::read(
     switch (control_level_[i])
     {
       case integration_level_t::UNDEFINED:
-        RCLCPP_INFO(get_logger(), "Nothing is using the hardware interface!");
+        RCLCPP_INFO_THROTTLE(
+          get_logger(), *get_clock(), 1000, "Nothing is using the hardware interface!");
         return hardware_interface::return_type::OK;
         break;
       case integration_level_t::POSITION:


### PR DESCRIPTION
I have the feeling that the log output at 100Hz clogs the RMW resulting in test errors like here
https://github.com/ros-controls/ros2_control_ci/issues/476