### PR TITLE
Robustify gazebo tests for gazebo jetty

### DIFF
--- a/example_9/test/test_rrbot_gazebo_launch.py
+++ b/example_9/test/test_rrbot_gazebo_launch.py
@@ -76,9 +76,11 @@ class TestFixture(unittest.TestCase):
     def tearDownClass(cls):
         for proc in psutil.process_iter():
             # check whether the process name matches
-            if proc.name() == "ruby":
+            if proc.name() == "ruby" or "gz sim" in proc.name():
+                # up to version 9 of gz-sim
                 proc.kill()
-            if "gz sim" in proc.name():
+            if "gz-sim" in proc.name():
+                # from version 10 of gz-sim
                 proc.kill()
         rclpy.shutdown()
 


### PR DESCRIPTION
Should fix https://github.com/ros-controls/ros2_control_ci/issues/479

See https://github.com/ros-controls/gz_ros2_control/pull/682 for the same fix in gz_ros2_control_tests