### PR TITLE
Update CMakeLists.txt to use add_ros_isolated_launch_test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       args: ["--ignore=D100,D101,D102,D103,D104,D105,D106,D107,D203,D212,D404"]
 
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 25.9.0
     hooks:
       - id: black
         args: ["--line-length=99"]
@@ -62,7 +62,7 @@ repos:
 
   # CPP hooks
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v21.1.0
+    rev: v21.1.2
     hooks:
       - id: clang-format
         args: ['-fallback-style=none', '-i']
@@ -131,7 +131,7 @@ repos:
         exclude: CHANGELOG\.rst|\.(svg|pyc)$
 
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.33.3
+    rev: 0.34.0
     hooks:
       - id: check-github-workflows
         args: ["--verbose"]

--- a/example_1/CMakeLists.txt
+++ b/example_1/CMakeLists.txt
@@ -71,11 +71,18 @@ install(TARGETS ros2_control_demo_example_1
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-
   ament_add_pytest_test(example_1_urdf_xacro test/test_urdf_xacro.py)
-  ament_add_pytest_test(view_example_1_launch test/test_view_robot_launch.py)
-  ament_add_pytest_test(run_example_1_launch test/test_rrbot_launch.py)
-  ament_add_pytest_test(run_example_1_launch_cli_direct test/test_rrbot_launch_cli_direct.py)
+
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_view_robot_launch.py)
+  add_ros_isolated_launch_test(test/test_rrbot_launch.py)
+  add_ros_isolated_launch_test(test/test_rrbot_launch_cli_direct.py)
 endif()
 
 

--- a/example_10/CMakeLists.txt
+++ b/example_10/CMakeLists.txt
@@ -71,10 +71,17 @@ install(TARGETS ros2_control_demo_example_10
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-
   ament_add_pytest_test(example_10_urdf_xacro test/test_urdf_xacro.py)
-  ament_add_pytest_test(view_example_10_launch test/test_view_robot_launch.py)
-  ament_add_pytest_test(run_example_10_launch test/test_rrbot_launch.py)
+
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_view_robot_launch.py)
+  add_ros_isolated_launch_test(test/test_rrbot_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_11/CMakeLists.txt
+++ b/example_11/CMakeLists.txt
@@ -71,11 +71,18 @@ install(TARGETS ros2_control_demo_example_11
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-
   ament_add_pytest_test(example_11_urdf_xacro test/test_urdf_xacro.py)
-  ament_add_pytest_test(view_example_11_launch test/test_view_robot_launch.py)
-  ament_add_pytest_test(run_example_11_launch test/test_carlikebot_launch.py)
-  ament_add_pytest_test(run_example_11_launch_remapped test/test_carlikebot_launch_remapped.py)
+
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_view_robot_launch.py)
+  add_ros_isolated_launch_test(test/test_carlikebot_launch.py)
+  add_ros_isolated_launch_test(test/test_carlikebot_launch_remapped.py)
 endif()
 
 ## EXPORTS

--- a/example_12/CMakeLists.txt
+++ b/example_12/CMakeLists.txt
@@ -114,10 +114,17 @@ install(TARGETS
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-
   ament_add_pytest_test(example_12_urdf_xacro test/test_urdf_xacro.py)
-  ament_add_pytest_test(view_example_12_launch test/test_view_robot_launch.py)
-  ament_add_pytest_test(run_example_12_launch test/test_rrbot_launch.py)
+
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_view_robot_launch.py)
+  add_ros_isolated_launch_test(test/test_rrbot_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_14/CMakeLists.txt
+++ b/example_14/CMakeLists.txt
@@ -74,10 +74,17 @@ install(TARGETS ros2_control_demo_example_14
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-
   ament_add_pytest_test(example_14_urdf_xacro test/test_urdf_xacro.py)
-  ament_add_pytest_test(view_example_14_launch test/test_view_robot_launch.py)
-  ament_add_pytest_test(run_example_14_launch test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py)
+
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_view_robot_launch.py)
+  add_ros_isolated_launch_test(test/test_rrbot_modular_actuators_without_feedback_sensors_for_position_feedback_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_15/CMakeLists.txt
+++ b/example_15/CMakeLists.txt
@@ -26,11 +26,15 @@ install(
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_pytest REQUIRED)
-
-  ament_add_pytest_test(test_rrbot_namespace_launch test/test_rrbot_namespace_launch.py)
-  ament_add_pytest_test(test_multi_controller_manager_launch test/test_multi_controller_manager_launch.py)
-
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_rrbot_namespace_launch.py)
+  add_ros_isolated_launch_test(test/test_multi_controller_manager_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_16/CMakeLists.txt
+++ b/example_16/CMakeLists.txt
@@ -71,10 +71,17 @@ install(TARGETS ros2_control_demo_example_16
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-
   ament_add_pytest_test(example_16_urdf_xacro test/test_urdf_xacro.py)
-  ament_add_pytest_test(view_example_16_launch test/test_view_robot_launch.py)
-  ament_add_pytest_test(run_example_16_launch test/test_diffbot_launch.py)
+
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_view_robot_launch.py)
+  add_ros_isolated_launch_test(test/test_diffbot_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_17/CMakeLists.txt
+++ b/example_17/CMakeLists.txt
@@ -73,10 +73,17 @@ install(TARGETS ros2_control_demo_example_17
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-
   ament_add_pytest_test(example_17_urdf_xacro test/test_urdf_xacro.py)
-  ament_add_pytest_test(view_example_17_launch test/test_view_robot_launch.py)
-  ament_add_pytest_test(run_example_17_launch test/test_rrbot_launch.py)
+
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_view_robot_launch.py)
+  add_ros_isolated_launch_test(test/test_rrbot_launch.py)
 endif()
 
 

--- a/example_2/CMakeLists.txt
+++ b/example_2/CMakeLists.txt
@@ -71,10 +71,17 @@ install(TARGETS ros2_control_demo_example_2
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-
   ament_add_pytest_test(example_2_urdf_xacro test/test_urdf_xacro.py)
-  ament_add_pytest_test(view_example_2_launch test/test_view_robot_launch.py)
-  ament_add_pytest_test(run_example_2_launch test/test_diffbot_launch.py)
+
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_view_robot_launch.py)
+  add_ros_isolated_launch_test(test/test_diffbot_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_3/CMakeLists.txt
+++ b/example_3/CMakeLists.txt
@@ -71,10 +71,17 @@ install(TARGETS ros2_control_demo_example_3
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-
   ament_add_pytest_test(example_3_urdf_xacro test/test_urdf_xacro.py)
-  ament_add_pytest_test(view_example_3_launch test/test_view_robot_launch.py)
-  ament_add_pytest_test(run_example_3_launch test/test_rrbot_system_multi_interface_launch.py)
+
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_view_robot_launch.py)
+  add_ros_isolated_launch_test(test/test_rrbot_system_multi_interface_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_4/CMakeLists.txt
+++ b/example_4/CMakeLists.txt
@@ -71,10 +71,17 @@ install(TARGETS ros2_control_demo_example_4
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-
   ament_add_pytest_test(example_4_urdf_xacro test/test_urdf_xacro.py)
-  ament_add_pytest_test(view_example_4_launch test/test_view_robot_launch.py)
-  ament_add_pytest_test(run_example_4_launch test/test_rrbot_system_with_sensor_launch.py)
+
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_view_robot_launch.py)
+  add_ros_isolated_launch_test(test/test_rrbot_system_with_sensor_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_5/CMakeLists.txt
+++ b/example_5/CMakeLists.txt
@@ -72,10 +72,17 @@ install(TARGETS ros2_control_demo_example_5
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-
   ament_add_pytest_test(example_5_urdf_xacro test/test_urdf_xacro.py)
-  ament_add_pytest_test(view_example_5_launch test/test_view_robot_launch.py)
-  ament_add_pytest_test(run_example_5_launch test/test_rrbot_system_with_external_sensor_launch.py)
+
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_view_robot_launch.py)
+  add_ros_isolated_launch_test(test/test_rrbot_system_with_external_sensor_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_6/CMakeLists.txt
+++ b/example_6/CMakeLists.txt
@@ -71,10 +71,17 @@ install(TARGETS ros2_control_demo_example_6
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-
   ament_add_pytest_test(example_6_urdf_xacro test/test_urdf_xacro.py)
-  ament_add_pytest_test(view_example_6_launch test/test_view_robot_launch.py)
-  ament_add_pytest_test(run_example_6_launch test/test_rrbot_modular_actuators_launch.py)
+
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_view_robot_launch.py)
+  add_ros_isolated_launch_test(test/test_rrbot_modular_actuators_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_7/CMakeLists.txt
+++ b/example_7/CMakeLists.txt
@@ -105,10 +105,17 @@ install(TARGETS ros2_control_demo_example_7
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-
   ament_add_pytest_test(example_7_urdf_xacro test/test_urdf_xacro.py)
-  ament_add_pytest_test(view_example_7_launch test/test_view_robot_launch.py)
-  ament_add_pytest_test(run_example_7_launch test/test_r6bot_controller_launch.py)
+
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_view_robot_launch.py)
+  add_ros_isolated_launch_test(test/test_r6bot_controller_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_8/CMakeLists.txt
+++ b/example_8/CMakeLists.txt
@@ -73,10 +73,17 @@ install(TARGETS ros2_control_demo_example_8
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-
   ament_add_pytest_test(example_8_urdf_xacro test/test_urdf_xacro.py)
-  ament_add_pytest_test(view_example_8_launch test/test_view_robot_launch.py)
-  ament_add_pytest_test(run_example_8_launch test/test_rrbot_transmissions_system_position_only_launch.py)
+
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_view_robot_launch.py)
+  add_ros_isolated_launch_test(test/test_rrbot_transmissions_system_position_only_launch.py)
 endif()
 
 ## EXPORTS

--- a/example_9/CMakeLists.txt
+++ b/example_9/CMakeLists.txt
@@ -71,11 +71,18 @@ install(TARGETS ros2_control_demo_example_9
 
 if(BUILD_TESTING)
   find_package(ament_cmake_pytest REQUIRED)
-
   ament_add_pytest_test(example_9_urdf_xacro test/test_urdf_xacro.py)
-  ament_add_pytest_test(view_example_9_launch test/test_view_robot_launch.py)
-  ament_add_pytest_test(run_example_9_launch test/test_rrbot_launch.py)
-  ament_add_pytest_test(run_example_9_gazebo_launch test/test_rrbot_gazebo_launch.py)
+
+  # Integration (launch) tests
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+  add_ros_isolated_launch_test(test/test_view_robot_launch.py)
+  add_ros_isolated_launch_test(test/test_rrbot_launch.py)
+  add_ros_isolated_launch_test(test/test_rrbot_gazebo_launch.py)
 endif()
 
 ## EXPORTS


### PR DESCRIPTION
This change should hopefully fix #872.
Basically I am updating all the CMakeLists.txt files to use "add_ros_isolated_launch_test" for the launch tests as mentioned in
https://docs.ros.org/en/rolling/Tutorials/Intermediate/Testing/Integration.html

I ran the tests locally and they all passed.