### PR TITLE
Cleaned up launch file example_1/rrbot.launch.py

### DIFF
--- a/example_1/bringup/launch/rrbot.launch.py
+++ b/example_1/bringup/launch/rrbot.launch.py
@@ -80,12 +80,13 @@ def generate_launch_description():
             Node(
                 package="controller_manager",
                 executable="spawner",
-                parameters=[
+                arguments=[
+                    "forward_position_controller",
+                    "--param-file",
                     PathSubstitution(FindPackageShare("ros2_control_demo_example_1"))
                     / "config"
-                    / "rrbot_controllers.yaml"
+                    / "rrbot_controllers.yaml",
                 ],
-                arguments=["forward_position_controller"],
             ),
         ]
     )


### PR DESCRIPTION
Addresses #950 by cleaning up a single launch file: example_1/rrbot.launch.py. This file has been improved to use a declarative programming style, as described by @emersonknapp at [ROSCon](https://roscon.ros.org/2025/), which can be viewed in the [livestream at 6:10](https://roscon.ros.org/2025/primary_live.html). A couple of local variables are needed for the Event Handlers, but all other unnecessary local variables are removed. 

This change is a draft PR for feedback before rolling out changes to other launch files in other examples. 