### PR TITLE
Show how custom CM name is working and how CM params don't have to be within yaml.

### DIFF
--- a/example_2/bringup/config/diffbot_controllers.yaml
+++ b/example_2/bringup/config/diffbot_controllers.yaml
@@ -1,9 +1,6 @@
-controller_manager:
+joint_state_broadcaster:
   ros__parameters:
-    update_rate: 10  # Hz
-
-    joint_state_broadcaster:
-      type: joint_state_broadcaster/JointStateBroadcaster
+    type: joint_state_broadcaster/JointStateBroadcaster
 
 diffbot_base_controller:
   ros__parameters:

--- a/example_2/bringup/launch/diffbot.launch.py
+++ b/example_2/bringup/launch/diffbot.launch.py
@@ -73,7 +73,8 @@ def generate_launch_description():
     control_node = Node(
         package="controller_manager",
         executable="ros2_control_node",
-        parameters=[robot_controllers],
+        name="controller_manager",
+        parameters=[{"update_rate": 10}],
         output="both",
     )
     robot_state_pub_node = Node(
@@ -94,7 +95,7 @@ def generate_launch_description():
     joint_state_broadcaster_spawner = Node(
         package="controller_manager",
         executable="spawner",
-        arguments=["joint_state_broadcaster"],
+        arguments=["joint_state_broadcaster", "-p", robot_controllers],
     )
 
     robot_controller_spawner = Node(
@@ -105,7 +106,7 @@ def generate_launch_description():
             "--param-file",
             robot_controllers,
             "--controller-ros-args",
-            "-r /diffbot_base_controller/cmd_vel:=/cmd_vel",
+            "-r ~/cmd_vel:=/cmd_vel",
         ],
     )
 

--- a/example_2/bringup/launch/diffbot.launch.xml
+++ b/example_2/bringup/launch/diffbot.launch.xml
@@ -1,0 +1,22 @@
+<launch>
+  <arg name="gui" default="true" description="Start RViz2 automatically with this launch file."/>
+  <arg name="use_mock_hardware" default="false" description="Start robot with mock hardware mirroring command to its states."/>
+
+  <let name="robot_description" value="$(command 'xacro $(find-pkg-share ros2_control_demo_example_2)/urdf/diffbot.urdf.xacro use_mock_hardware:=$(var use_mock_hardware)')"/>
+  <let name="robot_controllers" value="$(find-pkg-share ros2_control_demo_example_2)/config/diffbot_controllers.yaml"/>
+  <let name="rviz_config_file" value="$(find-pkg-share ros2_control_demo_description)/diffbot/rviz/diffbot.rviz"/>
+
+  <node pkg="controller_manager" exec="ros2_control_node" output="both" name="my_ctrl_mgr">
+    <param name="update_rate" value="10"/>
+  </node>
+
+  <node pkg="robot_state_publisher" exec="robot_state_publisher" output="both">
+    <param name="robot_description" value="$(var robot_description)"/>
+  </node>
+
+  <node pkg="rviz2" exec="rviz2" name="rviz2" output="log" args="-d $(var rviz_config_file)" if="$(var gui)"/>
+
+  <node pkg="controller_manager" exec="spawner" args="joint_state_broadcaster -c my_ctrl_mgr -p $(var robot_controllers)"/>
+
+  <node pkg="controller_manager" exec="spawner" args="diffbot_base_controller --controller-manager my_ctrl_mgr --param-file $(var robot_controllers) --controller-ros-args '-r ~/cmd_vel:=/cmd_vel'"/>
+</launch>

--- a/example_2/doc/userdoc.rst
+++ b/example_2/doc/userdoc.rst
@@ -18,6 +18,19 @@ The *DiffBot* URDF files can be found in ``description/urdf`` folder.
 
 .. include:: ../../doc/run_from_docker.rst
 
+This demo shows also how you can use custom controller manager name and simplify your configuration. Besided that provides also `.launch.xml` version of the launch file to direclty compare it with the `.launch.py` version.
+
+You can rename the ``controller_manager`` node, e.g., when want to separate the hardware management on the same machine. Check the `launch.py` to see the name set to default name and `launch.xml` to see how to set a custom name.
+
+   .. code-block:: shell
+
+    ros2 node list | grep diffbot
+
+   You should see the manager ``/my_diffbot_manager`` and the hardware node ``/diffbot`` (or similar, based on your URDF name).
+
+**Configuration Note**:
+The ``diffbot_controllers.yaml`` file demonstrates that you do not need to nest controller parameters under a ``controller_manager`` namespace. Since the spawner loads parameters directly for each controller, the YAML file can simply list the controllers at the root level. This makes the configuration more flexible and easier to reuse.
+
 Tutorial steps
 --------------------------
 

--- a/example_2/doc/userdoc.rst
+++ b/example_2/doc/userdoc.rst
@@ -18,9 +18,9 @@ The *DiffBot* URDF files can be found in ``description/urdf`` folder.
 
 .. include:: ../../doc/run_from_docker.rst
 
-This demo shows also how you can use custom controller manager name and simplify your configuration. Besided that provides also `.launch.xml` version of the launch file to direclty compare it with the `.launch.py` version.
+This demo shows also how you can use custom controller manager name and simplify your configuration. Besided that provides also ``.launch.xml`` version of the launch file to directly compare it with the ``.launch.py`` version.
 
-You can rename the ``controller_manager`` node, e.g., when want to separate the hardware management on the same machine. Check the `launch.py` to see the name set to default name and `launch.xml` to see how to set a custom name.
+You can rename the ``controller_manager`` node, e.g., when want to separate the hardware management on the same machine. Check the ``launch.py`` to see the name set to default name and ``launch.xml`` to see how to set a custom name.
 
    .. code-block:: shell
 

--- a/ros2_control_demos.rolling.repos
+++ b/ros2_control_demos.rolling.repos
@@ -10,7 +10,7 @@ repositories:
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
-    version: hotfix/no-name-overlapping-of-cm-when-custom
+    version: master
   ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers.git

--- a/ros2_control_demos.rolling.repos
+++ b/ros2_control_demos.rolling.repos
@@ -10,7 +10,7 @@ repositories:
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control.git
-    version: master
+    version: hotfix/no-name-overlapping-of-cm-when-custom
   ros2_controllers:
     type: git
     url: https://github.com/ros-controls/ros2_controllers.git


### PR DESCRIPTION
This PR also is used for testing the fix of the node name overlapping in ros2_control.

Needs https://github.com/ros-controls/ros2_control/pull/3006