### PR TITLE
Fix Windows build by replacing rand_r in demo hardware

### DIFF
--- a/example_10/hardware/rrbot.cpp
+++ b/example_10/hardware/rrbot.cpp
@@ -19,6 +19,7 @@
 #include <iomanip>
 #include <limits>
 #include <memory>
+#include <random>
 #include <sstream>
 #include <vector>
 
@@ -195,13 +196,15 @@ hardware_interface::return_type RRBotSystemWithGPIOHardware::read(
 
   // random inputs analog_input1 and analog_input2
   unsigned int seed = static_cast<unsigned int>(time(NULL)) + 1;
+  std::minstd_rand random_generator_1(seed);
   set_state(
     info_.gpios[0].name + "/" + info_.gpios[0].state_interfaces[1].name,
-    static_cast<double>(rand_r(&seed)));
+    static_cast<double>(random_generator_1()));
   seed = static_cast<unsigned int>(time(NULL)) + 2;
+  std::minstd_rand random_generator_2(seed);
   set_state(
     info_.gpios[0].name + "/" + info_.gpios[0].state_interfaces[2].name,
-    static_cast<double>(rand_r(&seed)));
+    static_cast<double>(random_generator_2()));
 
   for (const auto & [name, descr] : gpio_state_interfaces_)
   {

--- a/example_4/hardware/rrbot_system_with_sensor.cpp
+++ b/example_4/hardware/rrbot_system_with_sensor.cpp
@@ -23,6 +23,7 @@
 #include <iomanip>
 #include <limits>
 #include <memory>
+#include <random>
 #include <sstream>
 #include <vector>
 
@@ -183,9 +184,9 @@ hardware_interface::return_type RRBotSystemWithSensorHardware::read(
   {
     // Simulate RRBot's sensor data
     unsigned int seed = static_cast<unsigned int>(time(NULL)) + i++;
-    set_state(
-      name,
-      static_cast<double>(rand_r(&seed)) / (static_cast<double>(RAND_MAX / hw_sensor_change_)));
+    std::minstd_rand random_generator(seed);
+    std::uniform_real_distribution<double> distribution(0.0, hw_sensor_change_);
+    set_state(name, distribution(random_generator));
 
     ss << std::endl << "\t" << get_state(name) << " for sensor '" << name << "'";
   }

--- a/example_5/hardware/external_rrbot_force_torque_sensor.cpp
+++ b/example_5/hardware/external_rrbot_force_torque_sensor.cpp
@@ -23,6 +23,7 @@
 #include <iomanip>
 #include <limits>
 #include <memory>
+#include <random>
 #include <sstream>
 #include <vector>
 
@@ -97,9 +98,9 @@ hardware_interface::return_type ExternalRRBotForceTorqueSensorHardware::read(
   {
     // Simulate RRBot's sensor data
     unsigned int seed = static_cast<unsigned int>(time(NULL)) + i++;
-    set_state(
-      name,
-      static_cast<double>(rand_r(&seed)) / (static_cast<double>(RAND_MAX / hw_sensor_change_)));
+    std::minstd_rand random_generator(seed);
+    std::uniform_real_distribution<double> distribution(0.0, hw_sensor_change_);
+    set_state(name, distribution(random_generator));
 
     ss << std::endl << "\t" << get_state(name) << " for sensor '" << name << "'";
   }


### PR DESCRIPTION
` C:\target_ws\src\ros-controls\ros2_control_demos\example_5\hardware\external_rrbot_force_torque_sensor.cpp(102,27): error C3861: 'rand_r': identifier not found [C:\target_ws\build\ros2_control_demo_example_5\ros2_control_demo_example_5.vcxproj]`