### PR TITLE
Add Example 19 for DiffBot with launch_ros2_control

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,6 +96,16 @@ repos:
         language: system
         files: CMakeLists\.txt$
 
+  # XML hooks
+  - repo: local
+    hooks:
+      - id: ament_xmllint
+        name: ament_xmllint
+        description: Check format of XML files
+        entry: ament_xmllint
+        language: system
+        files: \.xml$
+
   # Copyright
   - repo: local
     hooks:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ The following examples are part of this demo repository:
 
    This example shows how to publish diagnostics from a hardware component using the Executor passed from Controller Manager.
 
+* Example 19: ["DiffBot with Conditionally Chained Controllers"](example_19)
+
+   This example shows how to create conditionally chained controllers using diff_drive_controller and pid_controllers to control a differential drive robot by using `launch_ros2_control`.
+
 ## Structure
 
 The repository is structured into `example_XY` folders that fully contained packages with names `ros2_control_demos_example_XY`.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -91,6 +91,9 @@ Example 16: "DiffBot with chained controllers"
 Example 17: "RRBot with Hardware Component that publishes diagnostics"
    This example shows how to publish diagnostics from a hardware component using the Executor passed from Controller Manager.
 
+Example 19: "DiffBot with Conditionally Chained Controllers"
+   This example shows how to create conditionally chained controllers using diff_drive_controller and pid_controllers to control a differential drive robot by using ``launch_ros2_control``.
+
 .. _ros2_control_demos_install:
 
 =====================
@@ -300,3 +303,4 @@ Examples
    Example 15: Using multiple controller managers <../example_15/doc/userdoc.rst>
    Example 16: DiffBot with chained controllers <../example_16/doc/userdoc.rst>
    Example 17: RRBot with Hardware Component that publishes diagnostics <../example_17/doc/userdoc.rst>
+   Example 19: DiffBot with Conditionally Chained Controllers <../example_19/doc/userdoc.rst>

--- a/example_19/CMakeLists.txt
+++ b/example_19/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.16)
+project(ros2_control_demo_example_19 LANGUAGES CXX)
+
+find_package(ros2_control_cmake REQUIRED)
+set_compiler_options()
+export_windows_symbols()
+
+# find dependencies
+set(THIS_PACKAGE_INCLUDE_DEPENDS
+)
+
+# Specify the required version of ros2_control
+find_package(controller_manager 4.0.0)
+# Handle the case where the required version is not found
+if(NOT controller_manager_FOUND)
+  message(FATAL_ERROR "ros2_control version 4.0.0 or higher is required. "
+  "Are you using the correct branch of the ros2_control_demos repository?")
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+foreach(Dependency IN ITEMS ${THIS_PACKAGE_INCLUDE_DEPENDS})
+  find_package(${Dependency} REQUIRED)
+endforeach()
+
+install(
+  DIRECTORY bringup/launch bringup/config
+  DESTINATION share/ros2_control_demo_example_19
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_ros REQUIRED)
+  find_package(launch_testing_ament_cmake REQUIRED)
+  find_package(ament_cmake_pytest REQUIRED)
+
+  function(add_ros_isolated_launch_test path)
+    set(RUNNER "${ament_cmake_ros_DIR}/run_test_isolated.py")
+    add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
+  endfunction()
+
+  foreach(launch_file_type IN ITEMS "py" "xml" "yaml")
+    add_ros_isolated_launch_test(
+      test/test_diffbot_example_2_launch.py
+      ARGS "type:=${launch_file_type}"
+      TARGET "diffbot_example_2.launch.${launch_file_type}")
+    add_ros_isolated_launch_test(
+      test/test_diffbot_example_16_launch.py
+      ARGS "type:=${launch_file_type}"
+      TARGET "diffbot_example_16.launch.${launch_file_type}")
+
+    add_ros_isolated_launch_test(
+      test/test_diffbot_example_2_16_launch_2.py
+      ARGS "type:=${launch_file_type}"
+      TARGET "diffbot_example_2_16_launch_2.launch.${launch_file_type}")
+    add_ros_isolated_launch_test(
+      test/test_diffbot_example_2_16_launch_16.py
+      ARGS "type:=${launch_file_type}"
+      TARGET "diffbot_example_2_16_launch_16.launch.${launch_file_type}")
+  endforeach()
+endif()
+
+## EXPORTS
+ament_export_dependencies(${THIS_PACKAGE_INCLUDE_DEPENDS})
+ament_package()

--- a/example_19/README.md
+++ b/example_19/README.md
@@ -1,0 +1,7 @@
+# ros2_control_demo_example_19
+
+   *DiffBot*, or ''Differential Mobile Robot'', is a simple mobile base with differential drive. This example shows how to create conditionally chained controllers using diff_drive_controller and pid_controllers to control a differential drive robot.
+   It demonstrates the of `launch_ros2_control` by reimplementing the launch files for [Example 2](https://control.ros.org/master/doc/ros2_control_demos/example_2/doc/userdoc.html) and [Example 16](https://control.ros.org/master/doc/ros2_control_demos/example_16/doc/userdoc.html).
+   A combined conditional setup is also demonstrated
+
+Find the documentation in [doc/userdoc.rst](doc/userdoc.rst) or on [control.ros.org](https://control.ros.org/master/doc/ros2_control_demos/example_19/doc/userdoc.html).

--- a/example_19/bringup/config/diffbot_pid_controllers.yaml
+++ b/example_19/bringup/config/diffbot_pid_controllers.yaml
@@ -1,0 +1,42 @@
+pid_controller_left_wheel_joint:
+  ros__parameters:
+    type: pid_controller/PidController
+
+    dof_names:
+      - left_wheel_joint
+
+    command_interface: velocity
+
+    reference_and_state_interfaces:
+      - velocity
+
+    gains:
+      # control the velocity, no d term
+      left_wheel_joint: {"p": 0.5, "i": 2.5, "d": 0.0, "i_clamp_min": -20.0, "i_clamp_max": 20.0, "antiwindup": true, "feedforward_gain": 0.95}
+
+pid_controller_right_wheel_joint:
+  ros__parameters:
+    type: pid_controller/PidController
+
+    dof_names:
+      - right_wheel_joint
+
+    command_interface: velocity
+
+    reference_and_state_interfaces:
+      - velocity
+
+    gains:
+      # control the velocity, no d term
+      right_wheel_joint: {"p": 0.5, "i": 2.5, "d": 0.0, "i_clamp_min": -20.0, "i_clamp_max": 20.0, "antiwindup": true, "feedforward_gain": 0.95}
+
+diffbot_base_controller:
+  ros__parameters:
+    # The type needs to be specified when overriding the config from the spawner
+    type: diff_drive_controller/DiffDriveController
+
+    left_wheel_names: ["pid_controller_left_wheel_joint/left_wheel_joint"]
+    right_wheel_names: ["pid_controller_right_wheel_joint/right_wheel_joint"]
+
+    # We can override parameters here
+    position_feedback: true

--- a/example_19/bringup/launch/diffbot_example_16.launch.py
+++ b/example_19/bringup/launch/diffbot_example_16.launch.py
@@ -1,0 +1,149 @@
+# Copyright 2025 Jasper van Brakel
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Based on ros-controls/ros2_control_demos/example16/bringup/launch/diffbot.launch.py
+
+# Launch-file for ros2_control_demos Example 16
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, SetLaunchConfiguration
+from launch.conditions import IfCondition
+from launch.substitutions import Command, LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+from launch_ros2_control.actions import SpawnControllers
+from launch_ros2_control.descriptions import Controller
+
+
+def generate_launch_description():
+    ld = LaunchDescription()
+    ld.add_action(
+        DeclareLaunchArgument(
+            "gui",
+            default_value="true",
+            description="Start RViz2 automatically with this launch file.",
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "use_mock_hardware",
+            default_value="false",
+            description="Start robot with mock hardware mirroring command to its states.",
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "fixed_frame_id", default_value="odom", description="Fixed frame id of the robot."
+        )
+    )
+
+    gui = LaunchConfiguration("gui")
+    use_mock_hardware = LaunchConfiguration("use_mock_hardware")
+    fixed_frame_id = LaunchConfiguration("fixed_frame_id")
+
+    demo_package_dir = PathJoinSubstitution([FindPackageShare("ros2_control_demo_example_16")])
+
+    ld.add_action(
+        SetLaunchConfiguration(
+            "robot_description_content",
+            Command(
+                [
+                    "xacro ",
+                    demo_package_dir / "urdf" / "diffbot.urdf.xacro",
+                    " use_mock_hardware:=",
+                    use_mock_hardware,
+                ]
+            ),
+        )
+    )
+
+    ld.add_action(
+        SetLaunchConfiguration(
+            "controller_config_file",
+            demo_package_dir / "config" / "diffbot_chained_controllers.yaml",
+        )
+    )
+
+    robot_description_content = LaunchConfiguration("robot_description_content")
+    controller_config_file = LaunchConfiguration("controller_config_file")
+
+    ld.add_action(
+        Node(
+            package="controller_manager",
+            executable="ros2_control_node",
+            output="both",
+            parameters=[controller_config_file],
+        )
+    )
+
+    ld.add_action(
+        Node(
+            package="robot_state_publisher",
+            executable="robot_state_publisher",
+            output="both",
+            parameters=[{"robot_description": robot_description_content}],
+        )
+    )
+
+    ld.add_action(
+        SpawnControllers(
+            [
+                Controller(
+                    name="pid_controller_left_wheel_joint",
+                    # This file can technically be omitted, since it is loaded
+                    # by the controller manager at startup
+                    parameters=[controller_config_file],
+                ),
+                Controller(
+                    name="pid_controller_right_wheel_joint",
+                    # This file can technically be omitted, since it is loaded
+                    # by the previous controller and by the controller manager at startup
+                    parameters=[controller_config_file],
+                ),
+                Controller(
+                    name="diffbot_base_controller",
+                    # This file can technically be omitted, since it is loaded
+                    # by the previous controller and by the controller manager at startup
+                    parameters=[controller_config_file],
+                    remappings=[("~/cmd_vel", "/cmd_vel")],
+                ),
+                Controller("joint_state_broadcaster"),
+            ]
+        )
+    )
+
+    ld.add_action(
+        Node(
+            package="rviz2",
+            executable="rviz2",
+            name="rviz2",
+            output="log",
+            arguments=[
+                "-d",
+                PathJoinSubstitution(
+                    [
+                        FindPackageShare("ros2_control_demo_description"),
+                        "diffbot",
+                        "rviz",
+                        "diffbot.rviz",
+                    ]
+                ),
+                "-f",
+                fixed_frame_id,
+            ],
+            condition=IfCondition(gui),
+        )
+    )
+
+    return ld

--- a/example_19/bringup/launch/diffbot_example_16.launch.xml
+++ b/example_19/bringup/launch/diffbot_example_16.launch.xml
@@ -1,0 +1,53 @@
+<!-- Launch-file for ros2_control_demos Example 16 -->
+<launch>
+  <arg name="gui" default="true"
+    description="Start RViz2 automatically with this launch file." />
+  <arg name="use_mock_hardware" default="false"
+    description="Start robot with mock hardware mirroring command to its states." />
+  <arg name="fixed_frame_id" default="odom"
+    description="Fixed frame id of the robot." />
+
+  <let name="robot_description_content"
+    value="
+    $(command '
+      xacro $(find-pkg-share ros2_control_demo_example_16)/urdf/diffbot.urdf.xacro
+      use_mock_hardware:=$(var use_mock_hardware)
+    ')" />
+
+  <let name="controller_config_file"
+    value="$(find-pkg-share ros2_control_demo_example_16)/config/diffbot_chained_controllers.yaml" />
+
+  <node pkg="controller_manager" exec="ros2_control_node" output="both">
+    <param from="$(var controller_config_file)" />
+  </node>
+
+  <node pkg="robot_state_publisher" exec="robot_state_publisher" output="both">
+    <param name="robot_description" value="$(var robot_description_content)" />
+  </node>
+
+  <spawn_controller>
+    <controller name="pid_controller_left_wheel_joint">
+      <!-- This file can technically be omitted, since it is loaded
+        by the controller manager at startup -->
+      <param from="$(var controller_config_file)" />
+    </controller>
+    <controller name="pid_controller_right_wheel_joint">
+      <!-- This file can technically be omitted, since it is loaded
+        by the previous controller and by the controller manager at startup -->
+      <param from="$(var controller_config_file)" />
+    </controller>
+
+    <controller name="diffbot_base_controller">
+      <!-- This file can technically be omitted, since it is loaded
+        by the previous controller and by the controller manager at startup -->
+      <param from="$(var controller_config_file)" />
+      <remap from="~/cmd_vel" to="/cmd_vel" />
+    </controller>
+    <controller name="joint_state_broadcaster" />
+  </spawn_controller>
+
+  <node pkg="rviz2" exec="rviz2" name="rviz2" output="log" if="$(var gui)"
+    args="
+    -d $(find-pkg-share ros2_control_demo_description)/diffbot/rviz/diffbot.rviz
+    -f $(var fixed_frame_id)" />
+</launch>

--- a/example_19/bringup/launch/diffbot_example_16.launch.yaml
+++ b/example_19/bringup/launch/diffbot_example_16.launch.yaml
@@ -1,0 +1,71 @@
+# Launch-file for ros2_control_demos Example 16
+launch:
+  - arg:
+      name: gui
+      default: "true"
+      description: Start RViz2 automatically with this launch file.
+  - arg:
+      name: use_mock_hardware
+      default: "false"
+      description: Start robot with mock hardware mirroring command to its states.
+  - arg:
+      name: fixed_frame_id
+      default: odom
+      description: Fixed frame id of the robot.
+
+  - let:
+      name: robot_description_content
+      value: >-
+        $(command '
+        xacro $(find-pkg-share ros2_control_demo_example_16)/urdf/diffbot.urdf.xacro
+        use_mock_hardware:=$(var use_mock_hardware)
+        ')
+
+  - let:
+      name: controller_config_file
+      value: $(find-pkg-share ros2_control_demo_example_16)/config/diffbot_chained_controllers.yaml
+
+  - node:
+      pkg: controller_manager
+      exec: ros2_control_node
+      output: both
+      param:
+        - from: $(var controller_config_file)
+
+  - node:
+      pkg: robot_state_publisher
+      exec: robot_state_publisher
+      output: both
+      param:
+        - { name: robot_description, value: $(var robot_description_content) }
+
+  - spawn_controller:
+      controller:
+        - name: pid_controller_left_wheel_joint
+          param:
+            # This file can technically be omitted, since it is loaded
+            # by the controller manager at startup
+            - from: $(var controller_config_file)
+        - name: pid_controller_right_wheel_joint
+          param:
+            # This file can technically be omitted, since it is loaded
+            # by the previous controller and by the controller manager at startup
+            - from: $(var controller_config_file)
+        - name: diffbot_base_controller
+          param:
+            # This file can technically be omitted, since it is loaded
+            # by the previous controller and by the controller manager at startup
+            - from: $(var controller_config_file)
+          remap:
+            - { from: "~/cmd_vel", to: "/cmd_vel" }
+        - name: joint_state_broadcaster
+
+  - node:
+      if: $(var gui)
+      pkg: rviz2
+      exec: rviz2
+      name: rviz2
+      output: log
+      args: >-
+        -d $(find-pkg-share ros2_control_demo_description)/diffbot/rviz/diffbot.rviz
+        -f $(var fixed_frame_id)

--- a/example_19/bringup/launch/diffbot_example_2.launch.py
+++ b/example_19/bringup/launch/diffbot_example_2.launch.py
@@ -1,0 +1,128 @@
+# Copyright 2025 Jasper van Brakel
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Based on ros-controls/ros2_control_demos/example2/bringup/launch/diffbot.launch.py
+
+# Launch-file for ros2_control_demos Example 2
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, SetLaunchConfiguration
+from launch.conditions import IfCondition
+from launch.substitutions import Command, LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+from launch_ros.substitutions import FindPackageShare
+from launch_ros2_control.actions import SpawnControllers
+from launch_ros2_control.descriptions import Controller
+
+
+def generate_launch_description():
+    ld = LaunchDescription()
+    ld.add_action(
+        DeclareLaunchArgument(
+            "gui",
+            default_value="true",
+            description="Start RViz2 automatically with this launch file.",
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "use_mock_hardware",
+            default_value="false",
+            description="Start robot with mock hardware mirroring command to its states.",
+        )
+    )
+
+    gui = LaunchConfiguration("gui")
+    use_mock_hardware = LaunchConfiguration("use_mock_hardware")
+
+    demo_package_dir = PathJoinSubstitution([FindPackageShare("ros2_control_demo_example_2")])
+
+    ld.add_action(
+        SetLaunchConfiguration(
+            "robot_description_content",
+            Command(
+                [
+                    "xacro ",
+                    demo_package_dir / "urdf" / "diffbot.urdf.xacro",
+                    " use_mock_hardware:=",
+                    use_mock_hardware,
+                ]
+            ),
+        )
+    )
+
+    ld.add_action(
+        SetLaunchConfiguration(
+            "controller_config_file", demo_package_dir / "config" / "diffbot_controllers.yaml"
+        )
+    )
+
+    robot_description_content = LaunchConfiguration("robot_description_content")
+    controller_config_file = LaunchConfiguration("controller_config_file")
+
+    ld.add_action(
+        Node(
+            package="controller_manager",
+            executable="ros2_control_node",
+            output="both",
+            parameters=[controller_config_file],
+        )
+    )
+
+    ld.add_action(
+        Node(
+            package="robot_state_publisher",
+            executable="robot_state_publisher",
+            output="both",
+            parameters=[{"robot_description": robot_description_content}],
+        )
+    )
+
+    ld.add_action(
+        SpawnControllers(
+            [
+                Controller(
+                    name="diffbot_base_controller",
+                    # This file can technically be omitted, since it is loaded
+                    # by the controller manager at startup
+                    parameters=[controller_config_file],
+                    remappings=[("~/cmd_vel", "/cmd_vel")],
+                ),
+                Controller("joint_state_broadcaster"),
+            ]
+        )
+    )
+
+    ld.add_action(
+        Node(
+            package="rviz2",
+            executable="rviz2",
+            name="rviz2",
+            output="log",
+            arguments=[
+                "-d",
+                PathJoinSubstitution(
+                    [
+                        FindPackageShare("ros2_control_demo_description"),
+                        "diffbot",
+                        "rviz",
+                        "diffbot.rviz",
+                    ]
+                ),
+            ],
+            condition=IfCondition(gui),
+        )
+    )
+
+    return ld

--- a/example_19/bringup/launch/diffbot_example_2.launch.xml
+++ b/example_19/bringup/launch/diffbot_example_2.launch.xml
@@ -1,0 +1,37 @@
+<!-- Launch-file for ros2_control_demos Example 2 -->
+<launch>
+  <arg name="gui" default="true"
+    description="Start RViz2 automatically with this launch file." />
+  <arg name="use_mock_hardware" default="false"
+    description="Start robot with mock hardware mirroring command to its states." />
+
+  <let name="robot_description_content"
+    value="
+    $(command '
+      xacro $(find-pkg-share ros2_control_demo_example_2)/urdf/diffbot.urdf.xacro
+      use_mock_hardware:=$(var use_mock_hardware)
+    ')" />
+
+  <let name="controller_config_file" value="$(find-pkg-share ros2_control_demo_example_2)/config/diffbot_controllers.yaml"/>
+
+  <node pkg="controller_manager" exec="ros2_control_node" output="both">
+    <param from="$(var controller_config_file)" />
+  </node>
+
+  <node pkg="robot_state_publisher" exec="robot_state_publisher" output="both">
+    <param name="robot_description" value="$(var robot_description_content)" />
+  </node>
+
+  <spawn_controller>
+    <controller name="diffbot_base_controller">
+      <!-- This file can technically be omitted, since it is loaded
+        by the controller manager at startup -->
+      <param from="$(var controller_config_file)" />
+      <remap from="~/cmd_vel" to="/cmd_vel" />
+    </controller>
+    <controller name="joint_state_broadcaster" />
+  </spawn_controller>
+
+  <node pkg="rviz2" exec="rviz2" name="rviz2" output="log" if="$(var gui)"
+    args="-d $(find-pkg-share ros2_control_demo_description)/diffbot/rviz/diffbot.rviz" />
+</launch>

--- a/example_19/bringup/launch/diffbot_example_2.launch.yaml
+++ b/example_19/bringup/launch/diffbot_example_2.launch.yaml
@@ -1,0 +1,56 @@
+# Launch-file for ros2_control_demos Example 2
+launch:
+  - arg:
+      name: gui
+      default: "true"
+      description: Start RViz2 automatically with this launch file.
+  - arg:
+      name: use_mock_hardware
+      default: "false"
+      description: Start robot with mock hardware mirroring command to its states.
+
+  - let:
+      name: robot_description_content
+      value: >-
+        $(command '
+        xacro $(find-pkg-share ros2_control_demo_example_2)/urdf/diffbot.urdf.xacro
+        use_mock_hardware:=$(var use_mock_hardware)
+        ')
+
+  - let:
+      name: controller_config_file
+      value: $(find-pkg-share ros2_control_demo_example_2)/config/diffbot_controllers.yaml
+
+  - node:
+      pkg: controller_manager
+      exec: ros2_control_node
+      output: both
+      param:
+        - from: $(var controller_config_file)
+
+  - node:
+      pkg: robot_state_publisher
+      exec: robot_state_publisher
+      output: both
+      param:
+        - { name: robot_description, value: $(var robot_description_content) }
+
+  - spawn_controller:
+      controller:
+        - name: diffbot_base_controller
+          param:
+            # This file can technically be omitted, since it is loaded
+            # by the controller manager at startup
+            - from: $(var controller_config_file)
+          remap:
+            - { from: "~/cmd_vel", to: "/cmd_vel" }
+        - name: joint_state_broadcaster
+
+  - node:
+      if: $(var gui)
+      pkg: rviz2
+      exec: rviz2
+      name: rviz2
+      output: log
+      args: >
+        -d $(find-pkg-share ros2_control_demo_description)/diffbot/rviz/diffbot.rviz

--- a/example_19/bringup/launch/diffbot_example_2_16.launch.py
+++ b/example_19/bringup/launch/diffbot_example_2_16.launch.py
@@ -1,0 +1,169 @@
+# Copyright 2025 Jasper van Brakel
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Based on ros-controls/ros2_control_demos/example16/bringup/launch/diffbot.launch.py
+
+# Launch-file for ros2_control_demos Example 2 and 16
+#   Provide optional PID controllers
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, SetLaunchConfiguration
+from launch.conditions import IfCondition
+from launch.substitutions import Command, LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node, SetParametersFromFile
+from launch_ros.substitutions import FindPackageShare
+from launch_ros2_control.actions import SpawnControllers
+from launch_ros2_control.descriptions import Controller
+
+
+def generate_launch_description():
+    ld = LaunchDescription()
+    ld.add_action(
+        DeclareLaunchArgument(
+            "gui",
+            default_value="true",
+            description="Start RViz2 automatically with this launch file.",
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "use_mock_hardware",
+            default_value="false",
+            description="Start robot with mock hardware mirroring command to its states.",
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "fixed_frame_id", default_value="odom", description="Fixed frame id of the robot."
+        )
+    )
+    ld.add_action(
+        DeclareLaunchArgument(
+            "use_pid", description="If true the PID controller for the wheels gets configured."
+        )
+    )
+
+    gui = LaunchConfiguration("gui")
+    use_mock_hardware = LaunchConfiguration("use_mock_hardware")
+    fixed_frame_id = LaunchConfiguration("fixed_frame_id")
+    use_pid = LaunchConfiguration("use_pid")
+
+    if_use_pid = IfCondition(use_pid)
+
+    ld.add_action(
+        SetLaunchConfiguration(
+            "robot_description_content",
+            Command(
+                [
+                    "xacro ",
+                    FindPackageShare("ros2_control_demo_example_16")
+                    / "urdf"
+                    / "diffbot.urdf.xacro",
+                    " use_mock_hardware:=",
+                    use_mock_hardware,
+                ]
+            ),
+        )
+    )
+
+    robot_description_content = LaunchConfiguration("robot_description_content")
+
+    diffbot_controller_parameters = PathJoinSubstitution(
+        [FindPackageShare("ros2_control_demo_example_2"), "config", "diffbot_controllers.yaml"]
+    )
+
+    ld.add_action(
+        Node(
+            package="controller_manager",
+            executable="ros2_control_node",
+            output="both",
+            parameters=[diffbot_controller_parameters],
+        )
+    )
+
+    ld.add_action(
+        Node(
+            package="robot_state_publisher",
+            executable="robot_state_publisher",
+            output="both",
+            parameters=[{"robot_description": robot_description_content}],
+        )
+    )
+
+    pid_controller_config_file = (
+        FindPackageShare("ros2_control_demo_example_19")
+        / "config"
+        / "diffbot_pid_controllers.yaml"
+    )
+
+    # Use global parameters to ensure parameter overriding happens in the correct order
+    ld.add_action(SetParametersFromFile(diffbot_controller_parameters))
+
+    ld.add_action(
+        SpawnControllers(
+            [
+                Controller(
+                    name="pid_controller_left_wheel_joint",
+                    # Load the config for the PID controllers,
+                    #  and small changes for diffbot_base_controller
+                    parameters=[pid_controller_config_file],
+                    condition=if_use_pid,
+                ),
+                Controller(
+                    name="pid_controller_right_wheel_joint",
+                    # This file can technically be omitted, since it is loaded by the previous controller
+                    parameters=[pid_controller_config_file],
+                    condition=if_use_pid,
+                ),
+                Controller(
+                    name="diffbot_base_controller",
+                    # Need to load controller type, since it is required if providing
+                    # controller configs at spawn time
+                    parameters=[
+                        {
+                            "type": "diff_drive_controller/DiffDriveController",
+                            "publish_limited_velocity": True,
+                        }
+                    ],
+                    remappings=[("~/cmd_vel", "/cmd_vel")],
+                ),
+                Controller("joint_state_broadcaster"),
+            ]
+        )
+    )
+
+    ld.add_action(
+        Node(
+            package="rviz2",
+            executable="rviz2",
+            name="rviz2",
+            output="log",
+            arguments=[
+                "-d",
+                PathJoinSubstitution(
+                    [
+                        FindPackageShare("ros2_control_demo_description"),
+                        "diffbot",
+                        "rviz",
+                        "diffbot.rviz",
+                    ]
+                ),
+                "-f",
+                fixed_frame_id,
+            ],
+            condition=IfCondition(gui),
+        )
+    )
+
+    return ld

--- a/example_19/bringup/launch/diffbot_example_2_16.launch.py
+++ b/example_19/bringup/launch/diffbot_example_2_16.launch.py
@@ -15,7 +15,7 @@
 # Based on ros-controls/ros2_control_demos/example16/bringup/launch/diffbot.launch.py
 
 # Launch-file for ros2_control_demos Example 2 and 16
-#   Provide optional PID controllers
+#   Provides optional PID controllers
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, SetLaunchConfiguration

--- a/example_19/bringup/launch/diffbot_example_2_16.launch.xml
+++ b/example_19/bringup/launch/diffbot_example_2_16.launch.xml
@@ -1,0 +1,56 @@
+<!-- Launch-file for ros2_control_demos Example 2 and 16 -->
+<!--   Provides optional PID controllers -->
+<launch>
+  <arg name="gui" default="true"
+    description="Start RViz2 automatically with this launch file." />
+  <arg name="use_mock_hardware" default="false"
+    description="Start robot with mock hardware mirroring command to its states." />
+  <arg name="fixed_frame_id" default="odom"
+    description="Fixed frame id of the robot." />
+  <arg name="use_pid" description="If true the PID controller for the wheels gets configured." />
+
+  <let name="robot_description_content"
+    value="
+    $(command '
+      xacro $(find-pkg-share ros2_control_demo_example_16)/urdf/diffbot.urdf.xacro
+      use_mock_hardware:=$(var use_mock_hardware)
+    ')" />
+
+  <node pkg="controller_manager" exec="ros2_control_node" output="both">
+    <!-- Load config from example 2 as a base -->
+    <param from="$(find-pkg-share ros2_control_demo_example_2)/config/diffbot_controllers.yaml" />
+  </node>
+
+  <node pkg="robot_state_publisher" exec="robot_state_publisher" output="both">
+    <param name="robot_description" value="$(var robot_description_content)" />
+  </node>
+
+  <!-- Use global parameters to ensure parameter overriding happens in the correct order -->
+  <set_parameters_from_file filename="$(find-pkg-share ros2_control_demo_example_2)/config/diffbot_controllers.yaml"/>
+
+  <spawn_controller>
+    <controller name="pid_controller_left_wheel_joint" if="$(var use_pid)">
+      <!-- Load the config for the PID controllers, and small changes for diffbot_base_controller -->
+      <param from="$(find-pkg-share ros2_control_demo_example_19)/config/diffbot_pid_controllers.yaml" />
+    </controller>
+    <controller name="pid_controller_right_wheel_joint" if="$(var use_pid)">
+      <!-- This file can technically be omitted, since it is loaded by the previous controller -->
+      <param from="$(find-pkg-share ros2_control_demo_example_19)/config/diffbot_pid_controllers.yaml" />
+    </controller>
+
+    <controller name="diffbot_base_controller">
+      <!-- Need to load controller type, since it is required if providing
+            controller configs at spawn time -->
+      <param name="type" value="diff_drive_controller/DiffDriveController" />
+      <param name="publish_limited_velocity" value="true" />
+
+      <remap from="~/cmd_vel" to="/cmd_vel" />
+    </controller>
+    <controller name="joint_state_broadcaster" />
+  </spawn_controller>
+
+  <node pkg="rviz2" exec="rviz2" name="rviz2" output="log" if="$(var gui)"
+    args="
+    -d $(find-pkg-share ros2_control_demo_description)/diffbot/rviz/diffbot.rviz
+    -f $(var fixed_frame_id)" />
+</launch>

--- a/example_19/bringup/launch/diffbot_example_2_16.launch.yaml
+++ b/example_19/bringup/launch/diffbot_example_2_16.launch.yaml
@@ -1,10 +1,5 @@
 # Launch-file for ros2_control_demos Example 2 and 16
-#   Provide optional PID controllers
-#   This example has the following requirements:
-#     - launch_yaml
-#     - ros-controls/ros2_control_demos (and it's requirements), specifically
-#       - ros2_control_demo_example_2
-#       - ros2_control_demo_example_16
+#   Provides optional PID controllers
 launch:
   - arg:
       name: gui

--- a/example_19/bringup/launch/diffbot_example_2_16.launch.yaml
+++ b/example_19/bringup/launch/diffbot_example_2_16.launch.yaml
@@ -1,0 +1,82 @@
+# Launch-file for ros2_control_demos Example 2 and 16
+#   Provide optional PID controllers
+#   This example has the following requirements:
+#     - launch_yaml
+#     - ros-controls/ros2_control_demos (and it's requirements), specifically
+#       - ros2_control_demo_example_2
+#       - ros2_control_demo_example_16
+launch:
+  - arg:
+      name: gui
+      default: "true"
+      description: Start RViz2 automatically with this launch file.
+  - arg:
+      name: use_mock_hardware
+      default: "false"
+      description: Start robot with mock hardware mirroring command to its states.
+  - arg:
+      name: fixed_frame_id
+      default: odom
+      description: Fixed frame id of the robot.
+  - arg:
+      name: use_pid
+      description: If true the PID controller for the wheels gets configured.
+
+  - let:
+      name: robot_description_content
+      value: >-
+        $(command '
+        xacro $(find-pkg-share ros2_control_demo_example_16)/urdf/diffbot.urdf.xacro
+        use_mock_hardware:=$(var use_mock_hardware)
+        ')
+
+  - node:
+      pkg: controller_manager
+      exec: ros2_control_node
+      output: both
+      param:
+        # Load config from example 2 as a base
+        - from: $(find-pkg-share ros2_control_demo_example_2)/config/diffbot_controllers.yaml
+
+  - node:
+      pkg: robot_state_publisher
+      exec: robot_state_publisher
+      output: both
+      param:
+        - { name: robot_description, value: $(var robot_description_content) }
+
+  # Use global parameters to ensure parameter overriding happens in the correct order
+  - set_parameters_from_file:
+      filename: $(find-pkg-share ros2_control_demo_example_2)/config/diffbot_controllers.yaml
+
+  - spawn_controller:
+      controller:
+        - name: pid_controller_left_wheel_joint
+          if: $(var use_pid)
+          param:
+            # Load the config for the PID controllers, and small changes for diffbot_base_controller
+            - from: $(find-pkg-share ros2_control_demo_example_19)/config/diffbot_pid_controllers.yaml
+        - name: pid_controller_right_wheel_joint
+          if: $(var use_pid)
+          param:
+            # This file can technically be omitted, since it is loaded by the previous controller
+            - from: $(find-pkg-share ros2_control_demo_example_19)/config/diffbot_pid_controllers.yaml
+        - name: diffbot_base_controller
+          param:
+            # Need to load controller type, since it is required if providing
+            # controller configs at spawn time
+            - { name: type, value: diff_drive_controller/DiffDriveController }
+            - { name: publish_limited_velocity, value: true }
+          remap:
+            - { from: "~/cmd_vel", to: "/cmd_vel" }
+        - name: joint_state_broadcaster
+
+  - node:
+      if: $(var gui)
+      pkg: rviz2
+      exec: rviz2
+      name: rviz2
+      output: log
+      args: >-
+        -d $(find-pkg-share ros2_control_demo_description)/diffbot/rviz/diffbot.rviz
+        -f $(var fixed_frame_id)

--- a/example_19/doc/userdoc.rst
+++ b/example_19/doc/userdoc.rst
@@ -1,0 +1,620 @@
+:github_url: https://github.com/ros-controls/ros2_control_demos/blob/{REPOS_FILE_BRANCH}/example_19/doc/userdoc.rst
+
+.. _ros2_control_demos_example_19_userdoc:
+
+Example 19: DiffBot with Optionally Chained controllers using ``launch_ros2_control``
+=====================================================================================
+
+This example demonstrates the use of ``launch_ros2_control`` on several *DiffBot* scenarios.
+This is done in three parts:
+
+1. Reimplement :ref:`Example 2: DiffBot <ros2_control_demos_example_2_userdoc>`
+2. Reimplement :ref:`Example 16: DiffBot with Chained Controllers <ros2_control_demos_example_16_userdoc>`
+3. *DiffBot* with Conditional Chained Controllers
+
+All these launch files are available as ``XML``, ``YAML`` and ``Python`` launch files.
+
+.. include:: ../../doc/run_from_docker.rst
+
+
+Tutorial steps
+--------------
+This example is split up in three parts to build up to the optional chained controller setup.
+
+.. contents:: Parts
+   :depth: 2
+   :local:
+
+
+Part 1: Reimplementing :ref:`Example 2 <ros2_control_demos_example_2_userdoc>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1. To start *DiffBot* in a configuration equivalent to Example 2 open a terminal, source your ROS2-workspace and the following launch file with
+
+   .. tabs::
+
+      .. group-tab:: XML
+
+         .. code-block:: shell
+
+            ros2 launch ros2_control_demo_example_19 diffbot_example_2.launch.xml
+
+      .. group-tab:: YAML
+
+         .. code-block:: shell
+
+            ros2 launch ros2_control_demo_example_19 diffbot_example_2.launch.yaml
+
+      .. group-tab:: Python
+
+         .. code-block:: shell
+
+            ros2 launch ros2_control_demo_example_19 diffbot_example_2.launch.py
+
+   The launch file loads and starts the robot hardware, controllers and opens *RViz* in a similar fashion to :ref:`Example 2 <ros2_control_demos_example_2_userdoc>`.
+   To validate the full tutorial of *example_2* can be followed starting from step 3.
+
+2. The used launch file looks as follows:
+
+   .. tabs::
+
+      .. group-tab:: XML
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2.launch.xml
+            :language: xml
+
+      .. group-tab:: YAML
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2.launch.yaml
+            :language: yaml
+
+      .. group-tab:: Python
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2.launch.py
+            :language: python
+
+   The arguments are defined at the start of the launch file.
+   These are both defined with a default to make them optional.
+
+   .. tabs::
+
+      .. group-tab:: XML
+
+         After which the robot description is expanded and stored in the ``robot_description_content`` launch configuration.
+
+         .. note::
+            The ``value`` attribute is separated over multiple lines in order to improve readability.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2.launch.xml
+            :language: xml
+            :lines: 8-13
+            :dedent:
+
+         Then the controller config filepath is stored in the ``controller_config_file`` launch configuration after which the ``robot_state_publisher`` and ``controller_manager`` nodes are started.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2.launch.xml
+            :language: xml
+            :lines: 15-23
+            :dedent:
+
+         Then the ``diffbot_base_controller`` and the ``joint_state_broadcaster`` are spawned using the ``<spawn_controller>`` action.
+         The two controllers are spawned with a single spawner, and only the ``cmd_vel`` topic of the ``diffbot_base_controller``` is remapped.
+         In this example the parameters for the ``joint_state_broadcaster`` have been omitted, as they are already loaded when loading the parameters for the ``diffbot_base_controller``
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2.launch.xml
+            :language: xml
+            :lines: 24-34
+            :dedent:
+
+
+      .. group-tab:: YAML
+
+         After which the robot description is expanded and stored in the ``robot_description_content`` launch configuration.
+
+         .. note::
+            The ``value`` attribute is separated over multiple lines in order to improve readability.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2.launch.yaml
+            :language: yaml
+            :lines: 12-18
+            :dedent:
+
+         Then the controller config filepath is stored in the ``controller_config_file`` launch configuration after which the ``robot_state_publisher`` and ``controller_manager`` nodes are started.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2.launch.yaml
+            :language: yaml
+            :lines: 20-36
+            :dedent:
+
+         Then the ``diffbot_base_controller`` and the ``joint_state_broadcaster`` are spawned using the ``spawn_controller`` action.
+         The two controllers are spawned with a single spawner, and only the ``cmd_vel`` topic of the ``diffbot_base_controller``` is remapped.
+         In this example the parameters for the ``joint_state_broadcaster`` have been omitted, as they are already loaded when loading the parameters for the ``diffbot_base_controller``
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2.launch.yaml
+            :language: yaml
+            :lines: 38-47
+            :dedent:
+
+
+      .. group-tab:: Python
+
+         After which the robot description is expanded and stored in the ``robot_description_content`` launch configuration.
+
+         .. note::
+            An extra ``demo_package_dir`` variable is defined, containing the substitution for the ``share`` directory path of *example_2*.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2.launch.py
+            :language: python
+            :lines: 49-63
+            :dedent:
+
+         Then the controller config filepath is stored in the ``controller_config_file`` launch configuration after which the ``robot_state_publisher`` and ``controller_manager`` nodes are started.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2.launch.py
+            :language: python
+            :lines: 65-90
+            :dedent:
+
+         Then the ``diffbot_base_controller`` and the ``joint_state_broadcaster`` are spawned using the ``SpawnControllers`` action.
+         The two controllers are spawned with a single spawner, and only the ``cmd_vel`` topic of the ``diffbot_base_controller``` is remapped.
+         In this example the parameters for the ``joint_state_broadcaster`` have been omitted, as they are already loaded when loading the parameters for the ``diffbot_base_controller``
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2.launch.py
+            :language: python
+            :lines: 92-105
+            :dedent:
+
+
+   All launch files end with starting *RViz*, which has been omitted for brevity.
+
+
+Part 2: Reimplementing :ref:`Example 16 <ros2_control_demos_example_16_userdoc>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1. To start *DiffBot* in a configuration equivalent to Example 16 open a terminal, source your ROS2-workspace and the following launch file with
+
+   .. tabs::
+
+      .. group-tab:: XML
+
+         .. code-block:: shell
+
+            ros2 launch ros2_control_demo_example_19 diffbot_example_16.launch.xml
+
+      .. group-tab:: YAML
+
+         .. code-block:: shell
+
+            ros2 launch ros2_control_demo_example_19 diffbot_example_16.launch.yaml
+
+      .. group-tab:: Python
+
+         .. code-block:: shell
+
+            ros2 launch ros2_control_demo_example_19 diffbot_example_16.launch.py
+
+   The launch file loads and starts the robot hardware, controllers and opens *RViz* in a similar fashion to :ref:`Example 16 <ros2_control_demos_example_16_userdoc>`.
+   To validate the full tutorial of *example_16* can be followed starting from step 2.
+
+2. The used launch file looks as follows:
+
+   .. tabs::
+
+      .. group-tab:: XML
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_16.launch.xml
+            :language: xml
+
+      .. group-tab:: YAML
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_16.launch.yaml
+            :language: yaml
+
+      .. group-tab:: Python
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_16.launch.py
+            :language: python
+
+
+   The arguments are defined at the start of the launch file.
+   These are both defined with a default to make them optional.
+
+   .. tabs::
+
+      .. group-tab:: XML
+
+         After which the robot description is expanded and stored in the ``robot_description_content`` launch configuration.
+
+         .. note::
+            The ``value`` attribute is separated over multiple lines in order to improve readability.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_16.launch.xml
+            :language: xml
+            :lines: 10-15
+            :dedent:
+
+         Then the controller config filepath is stored in the ``controller_config_file`` launch configuration after which the ``robot_state_publisher`` and ``controller_manager`` nodes are started.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_16.launch.xml
+            :language: xml
+            :lines: 17-26
+            :dedent:
+
+         Then the ``diffbot_base_controller``, the ``joint_state_broadcaster`` and both PID controllers are spawned using the ``<spawn_controller>`` action.
+         The four controllers are spawned with a single spawner, and only the ``cmd_vel`` topic of the ``diffbot_base_controller``` is remapped.
+         In this example the parameters for the ``joint_state_broadcaster`` have been omitted, as they are already loaded when loading the parameters for the ``diffbot_base_controller``
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_16.launch.xml
+            :language: xml
+            :lines: 27-47
+            :dedent:
+
+
+      .. group-tab:: YAML
+
+         After which the robot description is expanded and stored in the ``robot_description_content`` launch configuration.
+
+         .. note::
+            The ``value`` attribute is separated over multiple lines in order to improve readability.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_16.launch.yaml
+            :language: yaml
+            :lines: 15-22
+            :dedent:
+
+         Then the controller config filepath is stored in the ``controller_config_file`` launch configuration after which the ``robot_state_publisher`` and ``controller_manager`` nodes are started.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_16.launch.yaml
+            :language: yaml
+            :lines: 24-40
+            :dedent:
+
+         Then the ``diffbot_base_controller``, the ``joint_state_broadcaster`` and both PID controllers are spawned using the ``spawn_controller`` action.
+         The four controllers are spawned with a single spawner, and only the ``cmd_vel`` topic of the ``diffbot_base_controller``` is remapped.
+         In this example the parameters for the ``joint_state_broadcaster`` have been omitted, as they are already loaded when loading the parameters for the ``diffbot_base_controller``
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_16.launch.yaml
+            :language: yaml
+            :lines: 41-61
+            :dedent:
+
+
+      .. group-tab:: Python
+
+         After which the robot description is expanded and stored in the ``robot_description_content`` launch configuration.
+
+         .. note::
+            An extra ``demo_package_dir`` variable is defined, containing the substitution for the ``share`` directory path of *example_16*.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_16.launch.py
+            :language: python
+            :lines: 55-69
+            :dedent:
+
+         Then the controller config filepath is stored in the ``controller_config_file`` launch configuration after which the ``robot_state_publisher`` and ``controller_manager`` nodes are started.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_16.launch.py
+            :language: python
+            :lines: 71-97
+            :dedent:
+
+         Then the ``diffbot_base_controller``, the ``joint_state_broadcaster`` and both PID controllers are spawned using the ``SpawnControllers`` action.
+         The four controllers are spawned with a single spawner, and only the ``cmd_vel`` topic of the ``diffbot_base_controller``` is remapped.
+         In this example the parameters for the ``joint_state_broadcaster`` have been omitted, as they are already loaded when loading the parameters for the ``diffbot_base_controller``
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_16.launch.py
+            :language: python
+            :lines: 99-124
+            :dedent:
+
+
+   All launch files end with starting *RViz*, which has been omitted for brevity.
+
+
+Part 3: *DiffBot* with Conditional Chained Controllers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1. To start the conditional *DiffBot* example in a configuration equivalent to Example 2 open a terminal, source your ROS2-workspace and the following launch file with:
+
+   .. tabs::
+
+      .. group-tab:: XML
+
+         .. code-block:: shell
+
+            ros2 launch ros2_control_demo_example_19 diffbot_example_2_16.launch.xml use_pid:=False
+
+      .. group-tab:: YAML
+
+         .. code-block:: shell
+
+            ros2 launch ros2_control_demo_example_19 diffbot_example_2_16.launch.yaml use_pid:=False
+
+      .. group-tab:: Python
+
+         .. code-block:: shell
+
+            ros2 launch ros2_control_demo_example_19 diffbot_example_2_16.launch.py use_pid:=False
+
+   The launch file loads and starts the robot hardware, controllers and opens *RViz* in a similar fashion to :ref:`Example 2 <ros2_control_demos_example_2_userdoc>`.
+   To validate the full tutorial of *example_2* can be followed starting from step 3.
+
+
+2. Stop the previous launch file by pressing :kbd:`Ctrl-C`.
+   To now start the conditional *DiffBot* example in a configuration equivalent to Example 16 in the same terminal start following launch file with:
+
+   .. tabs::
+
+      .. group-tab:: XML
+
+         .. code-block:: shell
+
+            ros2 launch ros2_control_demo_example_19 diffbot_example_2_16.launch.xml use_pid:=True
+
+      .. group-tab:: YAML
+
+         .. code-block:: shell
+
+            ros2 launch ros2_control_demo_example_19 diffbot_example_2_16.launch.yaml use_pid:=True
+
+      .. group-tab:: Python
+
+         .. code-block:: shell
+
+            ros2 launch ros2_control_demo_example_19 diffbot_example_2_16.launch.py use_pid:=True
+
+   The launch file loads and starts the robot hardware, controllers and opens *RViz* in a similar fashion to :ref:`Example 16 <ros2_control_demos_example_16_userdoc>`.
+   To validate the full tutorial of *example_16* can be followed starting from step 2.
+
+
+3. The used launch file looks as follows:
+
+   .. tabs::
+
+      .. group-tab:: XML
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.xml
+            :language: xml
+
+      .. group-tab:: YAML
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.yaml
+            :language: yaml
+
+      .. group-tab:: Python
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.py
+            :language: python
+
+   The strategy used to achieve the toggle-able PID wheel controllers will be summarized here.
+   A new launch argument ``use_pid`` is introduced, which when set to some Truthy value, will enable the these extra controllers.
+   This is achieved by loading the base parameters from *example_2* as global parameters for the launch file.
+   This will make sure they are loaded by each node/controller, **before** the node/controller specific overrides are loaded.
+   The parameters for the PID controllers are only loaded when they are spawned, however they can also load parameters for other controllers.
+   This can be used to override the ``wheel_name`` parameters of the ``diffbot_base_controller`` to ensure the PID controller command interfaces are used.
+
+   This will now be highlighted in detail.
+
+   .. tabs::
+
+      .. group-tab:: XML
+
+         First, some general launch arguments are defined, after which the ``use_pid`` launch argument is defined.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.xml
+            :language: xml
+            :lines: 4-10
+            :emphasize-lines: 7
+            :dedent:
+
+         After which the robot description is expanded and stored in the ``robot_description_content`` launch configuration.
+
+         .. note::
+            The ``value`` attribute is separated over multiple lines in order to improve readability.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.xml
+            :language: xml
+            :lines: 12-17
+            :dedent:
+
+         Then the ``robot_state_publisher`` and ``controller_manager`` nodes are started.
+         The ``controller_manager`` loads the parameters from the PID-less setup.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.xml
+            :language: xml
+            :lines: 19-26
+            :emphasize-lines: 3
+            :dedent:
+
+         After which the PID-less controller config is loaded into the global parameters.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.xml
+            :language: xml
+            :lines: 27-29
+            :dedent:
+
+         Then all controllers are spawned using a single ``<spawn_controller>`` action.
+         The PID controllers are spawned **only** when the ``if`` attribute resolves to a truthy value.
+         These controllers load ``diffbot_pid_controllers.yaml`` which get combined with the global parameters from earlier.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.xml
+            :language: xml
+            :lines: 31-51
+            :dedent:
+
+
+      .. group-tab:: YAML
+
+         First, some general launch arguments are defined, after which the ``use_pid`` launch argument is defined.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.yaml
+            :language: yaml
+            :lines: 4-18
+            :emphasize-lines: 13-
+            :dedent:
+
+         After which the robot description is expanded and stored in the ``robot_description_content`` launch configuration.
+
+         .. note::
+            The ``value`` attribute is separated over multiple lines in order to improve readability.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.yaml
+            :language: yaml
+            :lines: 20-26
+            :dedent:
+
+         Then the ``robot_state_publisher`` and ``controller_manager`` nodes are started.
+         The ``controller_manager`` loads the parameters from the PID-less setup.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.yaml
+            :language: yaml
+            :lines: 27-42
+            :emphasize-lines: 7
+            :dedent:
+
+         After which the PID-less controller config is loaded into the global parameters.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.yaml
+            :language: yaml
+            :lines: 43-45
+            :dedent:
+
+         Then all controllers are spawned using a single ``spawn_controller`` action.
+         The PID controllers are spawned **only** when the ``if`` attribute resolves to a truthy value.
+         These controllers load ``diffbot_pid_controllers.yaml`` which get combined with the global parameters from earlier.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.yaml
+            :language: yaml
+            :lines: 47-67
+            :dedent:
+
+
+      .. group-tab:: Python
+
+         First, some general launch arguments are defined, after which the ``use_pid`` launch argument is defined.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.py
+            :language: python
+            :lines: 32-55
+            :emphasize-lines: 20-
+            :dedent:
+
+         Some additional variables for the previously defined launch configurations are defined in addition to a ``IfCondition`` for the use of ``use_pid``.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.py
+            :language: python
+            :lines: 57-62
+            :emphasize-lines: 6
+            :dedent:
+
+         After which the robot description is expanded and stored in the ``robot_description_content`` launch configuration.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.py
+            :language: python
+            :lines: 64-78
+            :dedent:
+
+         Then the ``robot_state_publisher`` and ``controller_manager`` nodes are started.
+         The ``controller_manager`` loads the parameters from the PID-less setup.
+
+         .. note::
+            Additional variables to contain (partial) launch configurations/substitutions are defined throughout the launch file to prevent repetition.
+            Most of these will be left out of this analysis for readability.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.py
+            :language: python
+            :lines: 82-102
+            :emphasize-lines: 1-3,10
+            :dedent:
+
+         After which the PID-less controller config is loaded into the global parameters.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.py
+            :language: python
+            :lines: 110-111
+            :dedent:
+
+         Then all controllers are spawned using a single ``SpawnController`` action.
+         The PID controllers are spawned **only** when the supplied ``condition`` argument resolves to a truthy value.
+         These controllers load ``diffbot_pid_controllers.yaml`` which get combined with the global parameters from earlier.
+
+         .. literalinclude:: ../bringup/launch/diffbot_example_2_16.launch.py
+            :language: python
+            :lines: 113-144
+            :dedent:
+
+
+   All launch files end with starting *RViz*, which has been omitted for brevity.
+
+   The content of the conditionally loaded parameter file ``diffbot_pid_controllers.yaml`` is:
+
+   .. literalinclude:: ../bringup/config/diffbot_pid_controllers.yaml
+      :language: yaml
+
+
+Files used for this demo
+------------------------
+
+Files of Part 1: Reimplementing Example 2
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Launch files:
+
+  * `diffbot_example_2.launch.xml <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_19/bringup/launch/diffbot_example_2.launch.xml>`__
+  * `diffbot_example_2.launch.yaml <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_19/bringup/launch/diffbot_example_2.launch.yaml>`__
+  * `diffbot_example_2.launch.py <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_19/bringup/launch/diffbot_example_2.launch.py>`__
+
+* Controllers yaml: `diffbot_controllers.yaml <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_2/bringup/config/diffbot_controllers.yaml>`__
+* URDF file: `diffbot.urdf.xacro <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_2/description/urdf/diffbot.urdf.xacro>`__
+
+  * Description: `diffbot_description.urdf.xacro <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/ros2_control_demo_description/diffbot/urdf/diffbot_description.urdf.xacro>`__
+  * ``ros2_control`` tag: `diffbot.ros2_control.xacro <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_2/description/ros2_control/diffbot.ros2_control.xacro>`__
+
+* RViz configuration: `diffbot.rviz <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/ros2_control_demo_description/diffbot/rviz/diffbot.rviz>`__
+
+* Hardware interface plugin: `diffbot_system.cpp <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_2/hardware/diffbot_system.cpp>`__
+
+
+Files of Part 2: Reimplementing Example 16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Launch files:
+
+  * `diffbot_example_16.launch.xml <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_19/bringup/launch/diffbot_example_16.launch.xml>`__
+  * `diffbot_example_16.launch.yaml <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_19/bringup/launch/diffbot_example_16.launch.yaml>`__
+  * `diffbot_example_16.launch.py <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_19/bringup/launch/diffbot_example_16.launch.py>`__
+
+* Controllers yaml: `diffbot_chained_controllers.yaml <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_16/bringup/config/diffbot_chained_controllers.yaml>`__
+* URDF file: `diffbot.urdf.xacro <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_16/description/urdf/diffbot.urdf.xacro>`__
+
+  * Description: `diffbot_description.urdf.xacro <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/ros2_control_demo_description/diffbot/urdf/diffbot_description.urdf.xacro>`__
+  * ``ros2_control`` tag: `diffbot.ros2_control.xacro <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_16/description/ros2_control/diffbot.ros2_control.xacro>`__
+
+* RViz configuration: `diffbot.rviz <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/ros2_control_demo_description/diffbot/rviz/diffbot.rviz>`__
+
+* Hardware interface plugin: `diffbot_system.cpp <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_16/hardware/diffbot_system.cpp>`__
+
+
+Files of Part 3: *DiffBot* with Conditional Chained Controllers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+* Launch files:
+
+  * `diffbot_example_2_16.launch.xml <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_19/bringup/launch/diffbot_example_2_16.launch.xml>`__
+  * `diffbot_example_2_16.launch.yaml <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_19/bringup/launch/diffbot_example_2_16.launch.yaml>`__
+  * `diffbot_example_2_16.launch.py <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_19/bringup/launch/diffbot_example_2_16.launch.py>`__
+
+* Controllers yaml:
+
+  * `diffbot_controllers.yaml <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_2/bringup/config/diffbot_controllers.yaml>`__
+  * `diffbot_pid_controllers.yaml <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_19/bringup/config/diffbot_pid_controllers.yaml>`__
+* URDF file: `diffbot.urdf.xacro <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_16/description/urdf/diffbot.urdf.xacro>`__
+
+  * Description: `diffbot_description.urdf.xacro <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/ros2_control_demo_description/diffbot/urdf/diffbot_description.urdf.xacro>`__
+  * ``ros2_control`` tag: `diffbot.ros2_control.xacro <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_16/description/ros2_control/diffbot.ros2_control.xacro>`__
+
+* RViz configuration: `diffbot.rviz <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/ros2_control_demo_description/diffbot/rviz/diffbot.rviz>`__
+
+* Hardware interface plugin: `diffbot_system.cpp <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_16/hardware/diffbot_system.cpp>`__
+
+
+Controllers from this demo
+--------------------------
+
+* ``Joint State Broadcaster`` (`ros2_controllers repository <https://github.com/ros-controls/ros2_controllers/tree/{REPOS_FILE_BRANCH}/joint_state_broadcaster>`__): :ref:`doc <joint_state_broadcaster_userdoc>`
+* ``Diff Drive Controller`` (`ros2_controllers repository <https://github.com/ros-controls/ros2_controllers/tree/{REPOS_FILE_BRANCH}/diff_drive_controller>`__): :ref:`doc <diff_drive_controller_userdoc>`
+* ``pid_controller`` (`ros2_controllers repository <https://github.com/ros-controls/ros2_controllers/tree/{REPOS_FILE_BRANCH}/pid_controller>`__): :ref:`doc <pid_controller_userdoc>`

--- a/example_19/package.xml
+++ b/example_19/package.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros2_control_demo_example_19</name>
+  <version>0.0.0</version>
+  <description>Demo package of `ros2_control` for Diffbot using launch_ros2_control.</description>
+
+  <maintainer email="denis.stogl@stoglrobotics.de">Dr.-Ing. Denis Štogl</maintainer>
+  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
+
+  <license>Apache-2.0</license>
+
+  <author email="36795178+SuperJappie08@users.noreply.github.com">Jasper van Brakel</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>ros2_control_cmake</build_depend>
+
+  <exec_depend>controller_manager</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>ros2_control_demo_example_2</exec_depend>
+  <exec_depend>ros2_control_demo_example_16</exec_depend>
+
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <exec_depend>launch_ros2_control</exec_depend>
+  <exec_depend>launch_xml</exec_depend>
+  <exec_depend>launch_yaml</exec_depend>
+
+  <exec_depend>ros2controlcli</exec_depend>
+  <exec_depend>ros2launch</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>rviz2</exec_depend>
+
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>launch_testing</test_depend>
+  <test_depend>launch</test_depend>
+  <test_depend>rclpy</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/example_19/test/test_diffbot_example_16_launch.py
+++ b/example_19/test/test_diffbot_example_16_launch.py
@@ -1,0 +1,86 @@
+# Copyright 2026 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch_testing.actions import ReadyToTest
+from launch_ros.substitutions import FindPackageShare
+from launch.substitutions import LaunchConfiguration, StringJoinSubstitution
+
+import launch_testing.markers
+import rclpy
+from controller_manager.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        FindPackageShare("ros2_control_demo_example_19")
+        / "launch"
+        / StringJoinSubstitution(["diffbot_example_16.launch.", LaunchConfiguration("type")]),
+        launch_arguments={"gui": "False"}.items(),
+    )
+
+    return LaunchDescription([DeclareLaunchArgument("type"), launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_node_start(self, proc_output):
+        check_node_running(self.node, "robot_state_publisher")
+
+    def test_controller_running(self, proc_output):
+        cnames = [
+            "pid_controller_left_wheel_joint",
+            "pid_controller_right_wheel_joint",
+            "diffbot_base_controller",
+            "joint_state_broadcaster",
+        ]
+
+        check_controllers_running(self.node, cnames)
+
+    def test_check_if_msgs_published(self):
+        check_if_js_published("/joint_states", ["left_wheel_joint", "right_wheel_joint"])
+
+
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_19/test/test_diffbot_example_2_16_launch_16.py
+++ b/example_19/test/test_diffbot_example_2_16_launch_16.py
@@ -1,0 +1,86 @@
+# Copyright 2026 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch_testing.actions import ReadyToTest
+from launch_ros.substitutions import FindPackageShare
+from launch.substitutions import LaunchConfiguration, StringJoinSubstitution
+
+import launch_testing.markers
+import rclpy
+from controller_manager.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        FindPackageShare("ros2_control_demo_example_19")
+        / "launch"
+        / StringJoinSubstitution(["diffbot_example_2_16.launch.", LaunchConfiguration("type")]),
+        launch_arguments={"gui": "False", "use_pid": "True"}.items(),
+    )
+
+    return LaunchDescription([DeclareLaunchArgument("type"), launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_node_start(self, proc_output):
+        check_node_running(self.node, "robot_state_publisher")
+
+    def test_controller_running(self, proc_output):
+        cnames = [
+            "pid_controller_left_wheel_joint",
+            "pid_controller_right_wheel_joint",
+            "diffbot_base_controller",
+            "joint_state_broadcaster",
+        ]
+
+        check_controllers_running(self.node, cnames)
+
+    def test_check_if_msgs_published(self):
+        check_if_js_published("/joint_states", ["left_wheel_joint", "right_wheel_joint"])
+
+
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_19/test/test_diffbot_example_2_16_launch_2.py
+++ b/example_19/test/test_diffbot_example_2_16_launch_2.py
@@ -1,0 +1,82 @@
+# Copyright 2026 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.substitutions import LaunchConfiguration, StringJoinSubstitution
+from launch_testing.actions import ReadyToTest
+from launch_ros.substitutions import FindPackageShare
+
+import launch_testing.markers
+import rclpy
+from controller_manager.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        FindPackageShare("ros2_control_demo_example_19")
+        / "launch"
+        / StringJoinSubstitution(["diffbot_example_2_16.launch.", LaunchConfiguration("type")]),
+        launch_arguments={"gui": "False", "use_pid": "False"}.items(),
+    )
+
+    return LaunchDescription([DeclareLaunchArgument("type"), launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_node_start(self, proc_output):
+        check_node_running(self.node, "robot_state_publisher")
+
+    def test_controller_running(self, proc_output):
+
+        cnames = ["diffbot_base_controller", "joint_state_broadcaster"]
+
+        check_controllers_running(self.node, cnames)
+
+    def test_check_if_msgs_published(self):
+        check_if_js_published("/joint_states", ["left_wheel_joint", "right_wheel_joint"])
+
+
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/example_19/test/test_diffbot_example_2_launch.py
+++ b/example_19/test/test_diffbot_example_2_launch.py
@@ -1,0 +1,82 @@
+# Copyright 2026 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.substitutions import LaunchConfiguration, StringJoinSubstitution
+from launch_testing.actions import ReadyToTest
+from launch_ros.substitutions import FindPackageShare
+
+import launch_testing.markers
+import rclpy
+from controller_manager.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
+
+
+# Executes the given launch file and checks if all nodes can be started
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        FindPackageShare("ros2_control_demo_example_19")
+        / "launch"
+        / StringJoinSubstitution(["diffbot_example_2.launch.", LaunchConfiguration("type")]),
+        launch_arguments={"gui": "False"}.items(),
+    )
+
+    return LaunchDescription([DeclareLaunchArgument("type"), launch_include, ReadyToTest()])
+
+
+# This is our test fixture. Each method is a test case.
+# These run alongside the processes specified in generate_test_description()
+class TestFixture(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_node_start(self, proc_output):
+        check_node_running(self.node, "robot_state_publisher")
+
+    def test_controller_running(self, proc_output):
+
+        cnames = ["diffbot_base_controller", "joint_state_broadcaster"]
+
+        check_controllers_running(self.node, cnames)
+
+    def test_check_if_msgs_published(self):
+        check_if_js_published("/joint_states", ["left_wheel_joint", "right_wheel_joint"])
+
+
+@launch_testing.post_shutdown_test()
+# These tests are run after the processes in generate_test_description() have shutdown.
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        """Check if the processes exited normally."""
+        launch_testing.asserts.assertExitCodes(proc_info)


### PR DESCRIPTION
Adds the examples previously found in [`SuperJappie08/launch_ros2_control`](https://github.com/SuperJappie08/launch_ros2_control).

Requires ros-controls/ros2_control#3122

## New Examples (Checklist)
- [x] The correct folder structure (described in the main [README.md](README.md))
- [x] Example has *doc/README.rst* with description
- [x] Detailed commands how to run an example
- [~] Output examples of CLI commands (handled similarly to other examples)

## Additional Information
It could probably use a thorough read-through.