### PR TITLE
Improve flaky test_r6bot_controller

### DIFF
--- a/example_7/test/test_r6bot_controller_launch.py
+++ b/example_7/test/test_r6bot_controller_launch.py
@@ -86,18 +86,16 @@ class TestFixture(unittest.TestCase):
     def test_node_start(self, proc_output):
         check_node_running(self.node, "robot_state_publisher")
 
-    def test_controller_running(self, proc_output):
-
-        cnames = ["r6bot_controller", "joint_state_broadcaster"]
-
-        check_controllers_running(self.node, cnames)
-
     def test_check_if_msgs_published(self):
         check_if_js_published(
             "/joint_states", ["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"]
         )
 
-    def test_check_if_trajectory_published(self, proc_output):
+    def test_check_if_trajectory_processed(self, proc_output):
+
+        cnames = ["r6bot_controller", "joint_state_broadcaster"]
+
+        check_controllers_running(self.node, cnames)
 
         topic = "/r6bot_controller/joint_trajectory"
 


### PR DESCRIPTION
```
    test_check_if_trajectory_published (ros2_control_demo_example_7.TestFixture) ... [INFO] [spawner-3]: process has finished cleanly [pid 40099]
    [INFO] [spawner-4]: process started with pid [40173]
    [INFO] [launch]: All log files can be found below /github/home/.ros/log/2026-03-25-06-08-29-099047-66df12e6b94c-40170
    [INFO] [launch]: Default logging verbosity is set to INFO
    [spawner-4] [INFO] [1774418909.160895623] [spawner_r6bot_controller]: waiting for service /controller_manager/list_controllers to become available...
    [INFO] [send_trajectory-1]: process started with pid [40190]
    [spawner-4] [INFO] [1774418909.670581468] [spawner_r6bot_controller]: Setting controller param "params_file" to "['/__w/ros2_control_ci/ros2_control_ci/target_ws/install/ros2_control_demo_example_7/share/ros2_control_demo_example_7/config/r6bot_controller.yaml']" for r6bot_controller
    [spawner-4] [INFO] [1774418909.677773897] [spawner_r6bot_controller]: Setting controller param "type" to "ros2_control_demo_example_7/RobotController" for r6bot_controller
    [ros2_control_node-1] [INFO] [1774418909.680864429] [controller_manager]: Loading controller : 'r6bot_controller' of type 'ros2_control_demo_example_7/RobotController'
    [ros2_control_node-1] [INFO] [1774418909.680900747] [controller_manager]: Loading controller 'r6bot_controller'
    [ros2_control_node-1] [INFO] [1774418909.682640791] [controller_manager]: Controller 'r6bot_controller' node arguments: --ros-args --params-file /__w/ros2_control_ci/ros2_control_ci/target_ws/install/ros2_control_demo_example_7/share/ros2_control_demo_example_7/config/r6bot_controller.yaml --params-file /__w/ros2_control_ci/ros2_control_ci/target_ws/install/ros2_control_demo_example_7/share/ros2_control_demo_example_7/config/r6bot_controller.yaml 
    [spawner-4] [INFO] [1774418909.724062275] [spawner_r6bot_controller]: Loaded r6bot_controller
    [ros2_control_node-1] [INFO] [1774418909.725567769] [controller_manager]: Configuring controller: 'r6bot_controller'
    FAIL
    test_controller_running (ros2_control_demo_example_7.TestFixture) ... [send_trajectory-1] [INFO] [1774418909.806176575] [send_trajectory_node]: Publishing trajectory with length 200
    [ros2_control_node-1] [INFO] [1774418909.807024497] [r6bot_controller]: Received new trajectory.
    [ros2_control_node-1] [INFO] [1774418909.824787301] [controller_manager]: Activating controllers: [ r6bot_controller ]
    [ros2_control_node-1] [INFO] [1774418909.923527393] [controller_manager]: Successfully switched controllers!
    [spawner-4] [INFO] [1774418910.024005662] [spawner_r6bot_controller]: Configured and activated r6bot_controller
    [INFO] [spawner-4]: process has finished cleanly [pid 40173]
    ok
    test_node_start (ros2_control_demo_example_7.TestFixture) ... ok
    
    ======================================================================
    FAIL: test_check_if_trajectory_published (ros2_control_demo_example_7.TestFixture)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/__w/ros2_control_ci/ros2_control_ci/target_ws/src/ros-controls/ros2_control_demos/example_7/test/test_r6bot_controller_launch.py", line 113, in test_check_if_trajectory_published
        assert len(pubs) > 0, f"No publisher for topic '{topic}' not found!"
    AssertionError: No publisher for topic '/r6bot_controller/joint_trajectory' not found!
    
    ----------------------------------------------------------------------
    Ran 4 tests in 3.971s

```
test_check_if_trajectory_published fails before running controller was checked
