### PR TITLE
Migrate example_3 controllers to ForwardCommandController

### DIFF
--- a/example_3/bringup/config/rrbot_multi_interface_forward_controllers.yaml
+++ b/example_3/bringup/config/rrbot_multi_interface_forward_controllers.yaml
@@ -7,17 +7,19 @@ controller_manager:
 
 forward_position_controller:
   ros__parameters:
-    type: position_controllers/JointGroupPositionController
+    type: forward_command_controller/ForwardCommandController
     joints:
       - joint1
       - joint2
+    interface_name: position
 
 forward_velocity_controller:
   ros__parameters:
-    type: velocity_controllers/JointGroupVelocityController
+    type: forward_command_controller/ForwardCommandController
     joints:
       - joint1
       - joint2
+    interface_name: velocity
 
 forward_acceleration_controller:
   ros__parameters:

--- a/example_3/doc/userdoc.rst
+++ b/example_3/doc/userdoc.rst
@@ -91,7 +91,7 @@ Tutorial steps
    .. code-block:: shell
 
     joint_state_broadcaster[joint_state_broadcaster/JointStateBroadcaster] active
-    forward_velocity_controller[velocity_controllers/JointGroupVelocityController] active
+    forward_velocity_controller[forward_command_controller/ForwardCommandController] active
 
    Check how this output changes if you use the different launch file arguments described above.
 


### PR DESCRIPTION
## Summary
Migrates deprecated JointGroup*Controller usage in example_3 to ForwardCommandController.

## Changes
- Updated controller types in YAML config
- Added required `interface_name` parameters (`position`, `velocity`)
- Updated documentation to reflect new controller type

## Testing
- Built `ros2_control_demos` successfully
- Launched `example_3` using:
```
ros2 launch ros2_control_demo_example_3 rrbot_system_multi_interface.launch.py
```
- Verified controllers load and run correctly
- Verified commands can be sent via CLI with no errors


Closes #970