### PR TITLE
[example_2] Add disable_commands parameter demo for MockHardware

### DIFF
--- a/example_2/bringup/launch/diffbot.launch.py
+++ b/example_2/bringup/launch/diffbot.launch.py
@@ -39,10 +39,18 @@ def generate_launch_description():
             description="Start robot with mock hardware mirroring command to its states.",
         )
     )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "disable_commands",
+            default_value="false",
+            description="Disable command mirroring in MockHardware, simulating a disconnected driver.",
+        )
+    )
 
     # Initialize Arguments
     gui = LaunchConfiguration("gui")
     use_mock_hardware = LaunchConfiguration("use_mock_hardware")
+    disable_commands = LaunchConfiguration("disable_commands")
 
     # Get URDF via xacro
     robot_description_content = Command(
@@ -55,6 +63,9 @@ def generate_launch_description():
             " ",
             "use_mock_hardware:=",
             use_mock_hardware,
+            " ",
+            "disable_commands:=",
+            disable_commands,
         ]
     )
     robot_description = {"robot_description": robot_description_content}

--- a/example_2/description/ros2_control/diffbot.ros2_control.xacro
+++ b/example_2/description/ros2_control/diffbot.ros2_control.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
-  <xacro:macro name="diffbot_ros2_control" params="name prefix use_mock_hardware">
+  <xacro:macro name="diffbot_ros2_control" params="name prefix use_mock_hardware disable_commands:=false">
 
     <ros2_control name="${name}" type="system">
       <xacro:unless value="${use_mock_hardware}">
@@ -15,6 +15,7 @@
         <hardware>
           <plugin>mock_components/GenericSystem</plugin>
           <param name="calculate_dynamics">true</param>
+          <param name="disable_commands">${disable_commands}</param>
         </hardware>
       </xacro:if>
       <joint name="${prefix}left_wheel_joint">

--- a/example_2/description/urdf/diffbot.urdf.xacro
+++ b/example_2/description/urdf/diffbot.urdf.xacro
@@ -3,6 +3,7 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="diffdrive_robot">
   <xacro:arg name="prefix" default="" />
   <xacro:arg name="use_mock_hardware" default="false" />
+  <xacro:arg name="disable_commands" default="false"/>
 
   <xacro:include filename="$(find ros2_control_demo_description)/diffbot/urdf/diffbot_description.urdf.xacro" />
 
@@ -15,6 +16,6 @@
   <xacro:diffbot prefix="$(arg prefix)" />
 
   <xacro:diffbot_ros2_control
-    name="DiffBot" prefix="$(arg prefix)" use_mock_hardware="$(arg use_mock_hardware)"/>
+    name="DiffBot" prefix="$(arg prefix)" use_mock_hardware="$(arg use_mock_hardware)" disable_commands="$(arg disable_commands)" />
 
 </robot>

--- a/example_2/doc/userdoc.rst
+++ b/example_2/doc/userdoc.rst
@@ -170,6 +170,40 @@ Tutorial steps
   checked by means of ``ros2 topic echo /joint_states``: The position values are increasing over time if the robot is moving.
   You now can test the setup with the commands from above, it should work identically as the custom hardware component plugin.
 
+  Another parameter of ``mock_components/GenericSystem`` is ``disable_commands``.
+  When set to ``true``, the hardware plugin stops mirroring commanded values to the state interfaces.
+  This simulates a disconnected driver scenario — commands are sent to the hardware successfully,
+  but no feedback signal is received back, as would happen with a broken encoder cable or a dropped network connection.
+
+  Stop the launch file and restart with an additional parameter:
+
+  .. code-block:: shell
+
+    ros2 launch ros2_control_demo_example_2 diffbot.launch.py use_mock_hardware:=True disable_commands:=True
+
+  Send velocity commands as before. Then check joint states:
+
+  .. code-block:: shell
+
+    ros2 topic echo /joint_states
+
+  You will notice that the position and velocity values **do not change** over time, even though commands are actively being published.
+  This is confirmed by the warning in the controller manager terminal:
+
+  .. code-block:: shell
+
+    [ros2_control_node-1] [WARN] [...] [controller_manager.hardware_component.system.DiffBot]: Command propagation is disabled - no values will be returned!
+
+  The relevant configuration in `diffbot.ros2_control.xacro <https://github.com/ros-controls/ros2_control_demos/tree/{REPOS_FILE_BRANCH}/example_2/description/ros2_control/diffbot.ros2_control.xacro>`__ is:
+
+  .. code-block:: xml
+
+    <hardware>
+      <plugin>mock_components/GenericSystem</plugin>
+      <param name="calculate_dynamics">true</param>
+      <param name="disable_commands">true</param>
+    </hardware>
+
   More information on mock_components can be found in the :ref:`ros2_control documentation <mock_components_userdoc>`.
 
 Files used for this demos


### PR DESCRIPTION
Closes #366

Adds a demonstration of the `disable_commands` parameter of `MockHardware` (`mock_components/GenericSystem`) to `example_2` (DiffBot)

---

## Background

Issue #366 was created after PR #136 became outdated due to repo restructuring.

`example_2` is the right place for this, as it already uses `mock_components/GenericSystem`. This PR simply adds `disable_commands` as an extension.

---

## What `disable_commands` does

By default, `MockHardware` mirrors every command value directly back as a state value:

```
controller sends velocity 1.0 rad/s
    → MockHardware writes state velocity = 1.0 rad/s
    → position accumulates over time
```

Setting `disable_commands: true` breaks this mirroring:

```xml
<param name="disable_commands">true</param>
```

- Commands are still accepted by the hardware plugin
- But **states never update** — they stay frozen at `0.0`
- No error is thrown — the system keeps running normally

This simulates a real hardware failure mode: commands go out successfully, but no encoder feedback comes back (e.g. broken cable, dropped fieldbus connection).

The controller manager confirms this every cycle:
```
[WARN] [controller_manager.hardware_component.system.DiffBot]: Command propagation is disabled - no values will be returned!
```

---

## Changes (4 files)

### `description/urdf/diffbot.urdf.xacro`
Added `disable_commands` as a top-level xacro argument (default: `false`) and passed it to the `diffbot_ros2_control` macro call. This is the entry point — xacro reads command-line arguments here and forwards them inward.

### `description/ros2_control/diffbot.ros2_control.xacro`
Added `disable_commands:=false` to the macro parameter list and embedded:
```xml
<param name="disable_commands">${disable_commands}</param>
```
inside the `MockHardware` block, alongside the existing `calculate_dynamics` param. This is where the value reaches the hardware plugin.

### `bringup/launch/diffbot.launch.py`
Added `disable_commands` as a `DeclareLaunchArgument` (default: `false`) and passed it into the `xacro Command(...)` substitution alongside `use_mock_hardware`. This exposes it on the command line.

### `doc/userdoc.rst`
Added a new paragraph directly after the `calculate_dynamics` explanation in step 6, covering:
- What `disable_commands` does conceptually
- The launch command to activate it
- Expected `ros2 topic echo /joint_states` output
- The controller manager warning that confirms it is working
- The relevant xacro configuration snippet

---

## How to Reproduce

### Baseline — Normal MockHardware (positions increase)

**Terminal 1:**
```bash
ros2 launch ros2_control_demo_example_2 diffbot.launch.py use_mock_hardware:=True
```

**Terminal 2:**
```bash
ros2 topic pub --rate 10 /cmd_vel geometry_msgs/msg/TwistStamped "
  header: auto
  twist:
    linear: {x: 0.7, y: 0.0, z: 0.0}
    angular: {x: 0.0, y: 0.0, z: 1.0}"
```

**Terminal 3:**
```bash
ros2 topic echo /joint_states
```

Expected result — positions climb continuously:
```
position:
- 13.2
- 13.3   ← increasing every cycle
velocity:
- 1.0
- 1.0
```
<img width="673" height="974" alt="Screenshot from 2026-04-04 07-04-39" src="https://github.com/user-attachments/assets/dd26bc2e-2b00-4080-b854-a48c79711e87" />
<img width="673" height="974" alt="Screenshot from 2026-04-04 07-04-42" src="https://github.com/user-attachments/assets/623a921c-c207-4e29-aff6-5ac60c48ebba" />

---

### With `disable_commands` — positions frozen

**Terminal 1:**
```bash
ros2 launch ros2_control_demo_example_2 diffbot.launch.py use_mock_hardware:=True disable_commands:=True
```

**Terminal 2:** same velocity command as above

**Terminal 3:**
```bash
ros2 topic echo /joint_states
```

Expected result — positions never move:
```
position:
- 0.0
- 0.0   ← frozen forever regardless of commands
velocity:
- 0.0
- 0.0
```

**Terminal 1 (controller manager)** simultaneously shows:
```
[WARN] [controller_manager.hardware_component.system.DiffBot]: Command propagation is disabled - no values will be returned!
```

This warning repeating every 100ms confirms `disable_commands` is active and working correctly.

<img width="671" height="963" alt="Screenshot from 2026-04-04 09-10-46" src="https://github.com/user-attachments/assets/7eed3941-560c-4919-a8a8-d7277b426deb" />
<img width="1825" height="951" alt="Screenshot from 2026-04-04 09-10-24" src="https://github.com/user-attachments/assets/4391e2e3-b496-4f8c-a26c-18efd8b1d670" />