### PR TITLE
Fix incorrect state interface index in Example 11 error log

### DIFF
--- a/example_11/hardware/carlikebot_system.cpp
+++ b/example_11/hardware/carlikebot_system.cpp
@@ -125,7 +125,7 @@ hardware_interface::CallbackReturn CarlikeBotSystemHardware::on_init(
       {
         RCLCPP_FATAL(
           get_logger(), "Joint '%s' has %s state interface. '%s' expected.", joint.name.c_str(),
-          joint.state_interfaces[1].name.c_str(), hardware_interface::HW_IF_VELOCITY);
+          joint.state_interfaces[0].name.c_str(), hardware_interface::HW_IF_VELOCITY);
         return hardware_interface::CallbackReturn::ERROR;
       }
 


### PR DESCRIPTION
This PR fixes a minor typo in Example 11's `carlikebot_system.cpp` error log.

The validation checks `joint.state_interfaces[0]` against `hardware_interface::HW_IF_VELOCITY`, but the fatal error message previously printed `joint.state_interfaces[1].name`. This could make the error message misleading when the validation fails.

## Changes

- Updated the error log to print `joint.state_interfaces[0].name`
- Made the reported interface index consistent with the interface being validated

## Before

```cpp
joint.state_interfaces[1].name.c_str()
```

## After
```cpp
joint.state_interfaces[0].name.c_str()
```