### PR TITLE
Remove the extra xacro path substitution

### DIFF
--- a/example_3/bringup/launch/rrbot_system_multi_interface.launch.py
+++ b/example_3/bringup/launch/rrbot_system_multi_interface.launch.py
@@ -26,7 +26,7 @@ def generate_launch_description():
     # Get URDF via xacro
     robot_description_content = Command(
         [
-            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            FindExecutable(name="xacro"),
             " ",
             PathJoinSubstitution(
                 [

--- a/example_7/bringup/launch/send_trajectory.launch.py
+++ b/example_7/bringup/launch/send_trajectory.launch.py
@@ -22,7 +22,7 @@ def generate_launch_description():
     # Get URDF via xacro
     robot_description_content = Command(
         [
-            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            FindExecutable(name="xacro"),
             " ",
             PathJoinSubstitution(
                 [

--- a/example_7/description/launch/view_r6bot.launch.py
+++ b/example_7/description/launch/view_r6bot.launch.py
@@ -37,7 +37,7 @@ def generate_launch_description():
     # Get URDF via xacro
     robot_description_content = Command(
         [
-            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            FindExecutable(name="xacro"),
             " ",
             PathJoinSubstitution(
                 [


### PR DESCRIPTION
Removes the unnecessary `PathJoinSubstitution` wrapper around `FindExecutable(name="xacro")` in the launch file referenced by #1118. The launch file still passes the xacro executable into the existing `Command` substitution, but no longer treats that executable lookup as a path-join operation. Verified with `python3 -m compileall -q example_7/bringup/launch/send_trajectory.launch.py` and `git diff --check`.
