### PR TITLE
Remove robot_description from example 15 control nodes

### DIFF
--- a/example_15/bringup/launch/rrbot_base.launch.py
+++ b/example_15/bringup/launch/rrbot_base.launch.py
@@ -178,7 +178,7 @@ def generate_launch_description():
         package="controller_manager",
         executable="ros2_control_node",
         namespace=namespace,
-        parameters=[robot_description, robot_controllers],
+        parameters=[robot_controllers],
         output="both",
     )
     robot_state_pub_node = Node(

--- a/example_15/bringup/launch/rrbot_namespace.launch.py
+++ b/example_15/bringup/launch/rrbot_namespace.launch.py
@@ -68,7 +68,7 @@ def generate_launch_description():
         package="controller_manager",
         executable="ros2_control_node",
         namespace="/rrbot",
-        parameters=[robot_description, robot_controllers],
+        parameters=[robot_controllers],
         output={
             "stdout": "screen",
             "stderr": "screen",


### PR DESCRIPTION
This removes the deprecated `robot_description` parameter from the `ros2_control_node` launches in example 15 while keeping it passed to `robot_state_publisher`. The controller manager now only receives the controller configuration, matching the follow-up requested in #1119.
