### PR TITLE
fix: remove deprecated robot_description from ros2_control_node and simplify FindExecutable substitution

### DIFF
--- a/example_15/bringup/launch/rrbot_base.launch.py
+++ b/example_15/bringup/launch/rrbot_base.launch.py
@@ -86,40 +86,11 @@ def generate_launch_description():
                 default_value="true",
                 description="Start RViz2 automatically with this launch file.",
             ),
-            # robot description from xacro
             Node(
                 package="controller_manager",
                 executable="ros2_control_node",
                 namespace=LaunchConfiguration("namespace"),
                 parameters=[
-                    {
-                        "robot_description": Command(
-                            [
-                                "xacro",
-                                " ",
-                                PathSubstitution(
-                                    FindPackageShare(LaunchConfiguration("description_package"))
-                                )
-                                / "urdf"
-                                / LaunchConfiguration("description_file"),
-                                " ",
-                                "prefix:=",
-                                LaunchConfiguration("prefix"),
-                                " ",
-                                "use_gazebo:=",
-                                LaunchConfiguration("use_gazebo"),
-                                " ",
-                                "use_mock_hardware:=",
-                                LaunchConfiguration("use_mock_hardware"),
-                                " ",
-                                "mock_sensor_commands:=",
-                                LaunchConfiguration("mock_sensor_commands"),
-                                " ",
-                                "slowdown:=",
-                                LaunchConfiguration("slowdown"),
-                            ]
-                        )
-                    },
                     PathSubstitution(
                         FindPackageShare(LaunchConfiguration("runtime_config_package"))
                     )

--- a/example_15/bringup/launch/rrbot_namespace.launch.py
+++ b/example_15/bringup/launch/rrbot_namespace.launch.py
@@ -16,7 +16,7 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.conditions import IfCondition
-from launch.substitutions import Command, LaunchConfiguration, PathSubstitution
+from launch.substitutions import Command, PathSubstitution
 
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
@@ -35,17 +35,6 @@ def generate_launch_description():
                 executable="ros2_control_node",
                 namespace="/rrbot",
                 parameters=[
-                    {
-                        "robot_description": Command(
-                            [
-                                "xacro",
-                                " ",
-                                PathSubstitution(FindPackageShare("ros2_control_demo_example_1"))
-                                / "urdf"
-                                / "rrbot.urdf.xacro",
-                            ]
-                        )
-                    },
                     PathSubstitution(FindPackageShare("ros2_control_demo_example_15"))
                     / "config"
                     / "rrbot_namespace_controllers.yaml",

--- a/example_3/bringup/launch/rrbot_system_multi_interface.launch.py
+++ b/example_3/bringup/launch/rrbot_system_multi_interface.launch.py
@@ -80,7 +80,7 @@ def generate_launch_description():
     # Get URDF via xacro
     robot_description_content = Command(
         [
-            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            FindExecutable(name="xacro"),
             " ",
             PathJoinSubstitution(
                 [

--- a/example_7/bringup/launch/send_trajectory.launch.py
+++ b/example_7/bringup/launch/send_trajectory.launch.py
@@ -30,7 +30,7 @@ def generate_launch_description():
                     {
                         "robot_description": Command(
                             [
-                                PathJoinSubstitution([FindExecutable(name="xacro")]),
+                                FindExecutable(name="xacro"),
                                 " ",
                                 PathJoinSubstitution(
                                     [

--- a/example_7/description/launch/view_r6bot.launch.py
+++ b/example_7/description/launch/view_r6bot.launch.py
@@ -37,7 +37,7 @@ def generate_launch_description():
     # Get URDF via xacro
     robot_description_content = Command(
         [
-            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            FindExecutable(name="xacro"),
             " ",
             PathJoinSubstitution(
                 [


### PR DESCRIPTION
Closes #1119
Closes #1118

**Changes**

`robot_description` parameter removed from `ros2_control_node` in `example_15`:
- `rrbot_base.launch.py`
- `rrbot_namespace.launch.py`

From Jazzy onwards `ros2_control_node` does not use this parameter — it is deprecated. `robot_state_publisher` still receives it correctly.

`PathJoinSubstitution` wrapper removed around `FindExecutable(name="xacro")` in:
- `example_3/bringup/launch/rrbot_system_multi_interface.launch.py`
- `example_7/bringup/launch/send_trajectory.launch.py`
- `example_7/description/launch/view_r6bot.launch.py`

`FindExecutable` already returns the full executable path, wrapping it in `PathJoinSubstitution` is redundant.