### PR TITLE
fix: suppress tf_frame_prefix deprecation warning in example_16

### DIFF
--- a/example_16/bringup/config/diffbot_chained_controllers.yaml
+++ b/example_16/bringup/config/diffbot_chained_controllers.yaml
@@ -70,6 +70,7 @@ diffbot_base_controller:
 
     open_loop: true
     enable_odom_tf: true
+    tf_frame_prefix: "~"
 
     cmd_vel_timeout: 0.5
     # set publish_limited_velocity to true for visualization


### PR DESCRIPTION
Closes #1029

Sets `tf_frame_prefix: "~"` in `diffbot_chained_controllers.yaml` for example_16.

After the parameter handling change in `diff_drive_controller` (ros-controls/ros2_controllers#1997), launching example_16 prints:

```
[WARN] Please use tilde ('~') character in 'tf_frame_prefix' as it replaced with node namespace
```

Setting `tf_frame_prefix: "~"` explicitly silences the warning and makes the behaviour match the new default.