### PR TITLE
fix(example_1) : fix forward_position_controller loading on kilted

### DIFF
--- a/example_1/bringup/config/rrbot_controllers.yaml
+++ b/example_1/bringup/config/rrbot_controllers.yaml
@@ -8,6 +8,6 @@ forward_position_controller:
   ros__parameters:
     type: forward_command_controller/ForwardCommandController
     joints:
-      - $(var joint_prefix)1
-      - $(var joint_prefix)2
+      - joint1
+      - joint2
     interface_name: position

--- a/example_1/bringup/launch/rrbot.launch.py
+++ b/example_1/bringup/launch/rrbot.launch.py
@@ -20,7 +20,6 @@ from launch.substitutions import Command, LaunchConfiguration, PathSubstitution
 
 from launch_ros.actions import Node
 from launch_ros.substitutions import FindPackageShare
-from launch_ros.parameter_descriptions import ParameterFile
 
 
 def generate_launch_description():
@@ -30,11 +29,6 @@ def generate_launch_description():
                 "gui",
                 default_value="true",
                 description="Start RViz2 automatically with this launch file.",
-            ),
-            DeclareLaunchArgument(
-                "joint_prefix",
-                default_value="joint",
-                description="Prefix for joint names (used with allow_substs in spawner).",
             ),
             # Control node
             Node(
@@ -88,17 +82,12 @@ def generate_launch_description():
             Node(
                 package="controller_manager",
                 executable="spawner",
-                parameters=[
-                    {"joint_prefix": LaunchConfiguration("joint_prefix")},
-                    ParameterFile(
-                        PathSubstitution(FindPackageShare("ros2_control_demo_example_1"))
-                        / "config"
-                        / "rrbot_controllers.yaml",
-                        allow_substs=True,
-                    ),
-                ],
                 arguments=[
                     "forward_position_controller",
+                    "--param-file",
+                    PathSubstitution(FindPackageShare("ros2_control_demo_example_1"))
+                    / "config"
+                    / "rrbot_controllers.yaml",
                 ],
             ),
         ]


### PR DESCRIPTION
Fixes : #1134
### Reason For Failure
In kilted, spawner no longer forwards its own node parameters to the controller_manager . Using ` parameters= ` with ParameterFile on the spawner Node means the 'type' param never reaches CM, causing fatal load failure.  I've verified from  example_9/10/12 pattern . 

After changes, local build was fine .

### Fixed

 pass config via --param-file in arguments= and hardcode joint names in YAML, consistent with example_9/10/12 pattern.