### PR TITLE
Fixes broken link introduced in #1131.

### DIFF
--- a/example_13/doc/userdoc.rst
+++ b/example_13/doc/userdoc.rst
@@ -496,4 +496,4 @@ Controllers from this demo
 --------------------------
 - ``Joint State Broadcaster`` (`ros2_controllers repository <https://github.com/ros-controls/ros2_controllers/tree/{REPOS_FILE_BRANCH}/joint_state_broadcaster>`__): `doc <https://control.ros.org/{REPOS_FILE_BRANCH}/doc/ros2_controllers/joint_state_broadcaster/doc/userdoc.html>`__
 - ``Forward Command Controller`` (`ros2_controllers repository <https://github.com/ros-controls/ros2_controllers/tree/{REPOS_FILE_BRANCH}/forward_command_controller>`__): `doc <https://control.ros.org/{REPOS_FILE_BRANCH}/doc/ros2_controllers/forward_command_controller/doc/userdoc.html>`__
-- ``rqt Controller Manager`` (`ros2_control repository <https://github.com/ros-controls/ros2_control/tree/{REPOS_FILE_BRANCH}/rqt_controller_manager>`__): `doc <https://control.ros.org/{REPOS_FILE_BRANCH}/doc/ros2_control/controller_manager/doc/userdoc.html>`__
+- ``rqt Controller Manager`` (`ros2_control repository <https://github.com/ros-controls/ros2_control/tree/{REPOS_FILE_BRANCH}/rqt_controller_manager>`__): `doc <https://control.ros.org/{REPOS_FILE_BRANCH}/doc/ros2_control/controller_manager/doc/userdoc.html#rqt-controller-manager>`__

--- a/example_13/doc/userdoc.rst
+++ b/example_13/doc/userdoc.rst
@@ -496,4 +496,4 @@ Controllers from this demo
 --------------------------
 - ``Joint State Broadcaster`` (`ros2_controllers repository <https://github.com/ros-controls/ros2_controllers/tree/{REPOS_FILE_BRANCH}/joint_state_broadcaster>`__): `doc <https://control.ros.org/{REPOS_FILE_BRANCH}/doc/ros2_controllers/joint_state_broadcaster/doc/userdoc.html>`__
 - ``Forward Command Controller`` (`ros2_controllers repository <https://github.com/ros-controls/ros2_controllers/tree/{REPOS_FILE_BRANCH}/forward_command_controller>`__): `doc <https://control.ros.org/{REPOS_FILE_BRANCH}/doc/ros2_controllers/forward_command_controller/doc/userdoc.html>`__
-- ``rqt Controller Manager`` (`ros2_control repository <https://github.com/ros-controls/ros2_control/tree/{REPOS_FILE_BRANCH}/rqt_controller_manager>`__): `doc <https://control.ros.org/{REPOS_FILE_BRANCH}/doc/ros2_control/rqt_controller_manager/userdoc.html>`__
+- ``rqt Controller Manager`` (`ros2_control repository <https://github.com/ros-controls/ros2_control/tree/{REPOS_FILE_BRANCH}/rqt_controller_manager>`__): `doc <https://control.ros.org/{REPOS_FILE_BRANCH}/doc/ros2_control/controller_manager/doc/userdoc.html>`__


### PR DESCRIPTION
Updated the link for 'rqt Controller Manager' documentation.

## General
The URL `control.ros.org/.../rqt_controller_manager/userdoc.html` does not exist —
rqt_controller_manager is documented inside the controller_manager userdoc, not as
a standalone page.

Closes #1147 
