### PR TITLE
define 'controller_manager' as build dependency as it is used in CMake

### DIFF
--- a/example_1/package.xml
+++ b/example_1/package.xml
@@ -22,8 +22,8 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>controller_manager</depend>
 
-  <exec_depend>controller_manager</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>

--- a/example_10/package.xml
+++ b/example_10/package.xml
@@ -22,8 +22,8 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>controller_manager</depend>
 
-  <exec_depend>controller_manager</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>gpio_controllers</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>

--- a/example_11/package.xml
+++ b/example_11/package.xml
@@ -22,9 +22,9 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>controller_manager</depend>
 
   <exec_depend>bicycle_steering_controller</exec_depend>
-  <exec_depend>controller_manager</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>

--- a/example_12/package.xml
+++ b/example_12/package.xml
@@ -24,8 +24,8 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>std_msgs</depend>
+  <depend>controller_manager</depend>
 
-  <exec_depend>controller_manager</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>

--- a/example_13/package.xml
+++ b/example_13/package.xml
@@ -18,7 +18,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>ros2_control_cmake</build_depend>
 
-  <exec_depend>controller_manager</exec_depend>
+  <depend>controller_manager</depend>
+
   <exec_depend>force_torque_sensor_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>

--- a/example_14/package.xml
+++ b/example_14/package.xml
@@ -20,8 +20,8 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>realtime_tools</depend>
+  <depend>controller_manager</depend>
 
-  <exec_depend>controller_manager</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>

--- a/example_15/package.xml
+++ b/example_15/package.xml
@@ -18,7 +18,8 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <build_depend>ros2_control_cmake</build_depend>
 
-  <exec_depend>controller_manager</exec_depend>
+  <depend>controller_manager</depend>
+
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_trajectory_controller</exec_depend>

--- a/example_16/package.xml
+++ b/example_16/package.xml
@@ -22,8 +22,8 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>controller_manager</depend>
 
-  <exec_depend>controller_manager</exec_depend>
   <exec_depend>diff_drive_controller</exec_depend>
   <exec_depend>pid_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>

--- a/example_17/package.xml
+++ b/example_17/package.xml
@@ -23,8 +23,8 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>controller_manager</depend>
 
-  <exec_depend>controller_manager</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>

--- a/example_2/package.xml
+++ b/example_2/package.xml
@@ -22,8 +22,8 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>controller_manager</depend>
 
-  <exec_depend>controller_manager</exec_depend>
   <exec_depend>diff_drive_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>

--- a/example_3/package.xml
+++ b/example_3/package.xml
@@ -20,8 +20,8 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>controller_manager</depend>
 
-  <exec_depend>controller_manager</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>

--- a/example_4/package.xml
+++ b/example_4/package.xml
@@ -20,8 +20,8 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>controller_manager</depend>
 
-  <exec_depend>controller_manager</exec_depend>
   <exec_depend>force_torque_sensor_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>

--- a/example_5/package.xml
+++ b/example_5/package.xml
@@ -20,8 +20,8 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>controller_manager</depend>
 
-  <exec_depend>controller_manager</exec_depend>
   <exec_depend>force_torque_sensor_broadcaster</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>

--- a/example_6/package.xml
+++ b/example_6/package.xml
@@ -20,8 +20,8 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>controller_manager</depend>
 
-  <exec_depend>controller_manager</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>

--- a/example_7/package.xml
+++ b/example_7/package.xml
@@ -27,8 +27,8 @@
   <depend>rclcpp</depend>
   <depend>realtime_tools</depend>
   <depend>trajectory_msgs</depend>
+  <depend>controller_manager</depend>
 
-  <exec_depend>controller_manager</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>launch_ros</exec_depend>

--- a/example_8/package.xml
+++ b/example_8/package.xml
@@ -23,8 +23,8 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
   <depend>transmission_interface</depend>
+  <depend>controller_manager</depend>
 
-  <exec_depend>controller_manager</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>

--- a/example_9/package.xml
+++ b/example_9/package.xml
@@ -23,8 +23,8 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
+  <depend>controller_manager</depend>
 
-  <exec_depend>controller_manager</exec_depend>
   <exec_depend>forward_command_controller</exec_depend>
   <exec_depend>ros_gz_bridge</exec_depend>
   <exec_depend>ros_gz_sim</exec_depend>


### PR DESCRIPTION
## General

Since `controller_manager` is requested in the `CMakeLists.txt`, it has to be deifned as a build dependency.

## New Examples
If you propose adding a new example, make sure that your new example has:

- [ ] The correct folder structure (described in the main [README.md](README.md))
- [ ] Example has *doc/README.rst* with description
- [ ] Detailed commands how to run an example
- [ ] Output examples of CLI commands
- [ ] Screenshots with expected visualizations (if applicable)
