### PR TITLE
Add shared ros2_control_demo_test_utils package

### DIFF
--- a/example_1/CMakeLists.txt
+++ b/example_1/CMakeLists.txt
@@ -82,6 +82,7 @@ if(BUILD_TESTING)
   add_ros_isolated_launch_test(test/test_view_robot_launch.py)
   add_ros_isolated_launch_test(test/test_rrbot_launch.py)
   add_ros_isolated_launch_test(test/test_rrbot_launch_cli_direct.py)
+  add_ros_isolated_launch_test(test/test_rrbot_movement.py)
 endif()
 
 

--- a/example_1/package.xml
+++ b/example_1/package.xml
@@ -44,6 +44,7 @@
   <test_depend>launch</test_depend>
   <test_depend>liburdfdom-tools</test_depend>
   <test_depend>rclpy</test_depend>
+  <test_depend>ros2_control_demo_test_utils</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/example_1/test/test_rrbot_movement.py
+++ b/example_1/test/test_rrbot_movement.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import unittest
 
 import pytest
 
-from ament_index_python.packages import get_package_share_directory
 from controller_manager.test_utils import (
     check_controllers_running,
     check_if_js_published,
@@ -25,9 +23,10 @@ from controller_manager.test_utils import (
 )
 from launch import LaunchDescription
 from launch.actions import IncludeLaunchDescription
-from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch_ros.actions import Node
 from launch_testing.actions import ReadyToTest
+from launch.substitutions import PathJoinSubstitution
+from launch_ros.substitutions import FindPackageShare
 
 import launch_testing
 import launch_testing.markers
@@ -37,11 +36,12 @@ import rclpy
 @pytest.mark.rostest
 def generate_test_description():
     launch_include = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            os.path.join(
-                get_package_share_directory("ros2_control_demo_example_1"),
-                "launch/rrbot.launch.py",
-            )
+        PathJoinSubstitution(
+            [
+                FindPackageShare("ros2_control_demo_example_1"),
+                "launch",
+                "rrbot.launch.py",
+            ]
         ),
         launch_arguments={"gui": "False"}.items(),
     )

--- a/example_1/test/test_rrbot_movement.py
+++ b/example_1/test/test_rrbot_movement.py
@@ -1,0 +1,98 @@
+# Copyright 2026 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+
+import pytest
+
+from ament_index_python.packages import get_package_share_directory
+from controller_manager.test_utils import (
+    check_controllers_running,
+    check_if_js_published,
+    check_node_running,
+)
+from launch import LaunchDescription
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch_ros.actions import Node
+from launch_testing.actions import ReadyToTest
+
+import launch_testing
+import launch_testing.markers
+import rclpy
+
+
+@pytest.mark.rostest
+def generate_test_description():
+    launch_include = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            os.path.join(
+                get_package_share_directory("ros2_control_demo_example_1"),
+                "launch/rrbot.launch.py",
+            )
+        ),
+        launch_arguments={"gui": "False"}.items(),
+    )
+
+    return LaunchDescription([launch_include, ReadyToTest()])
+
+
+class TestMovement(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node("test_node")
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def test_node_start(self, proc_output):
+        check_node_running(self.node, "robot_state_publisher")
+
+    def test_controller_running(self, proc_output):
+        cnames = ["forward_position_controller", "joint_state_broadcaster"]
+        check_controllers_running(self.node, cnames)
+
+    def test_check_if_msgs_published(self):
+        check_if_js_published("/joint_states", ["joint1", "joint2"])
+
+    def test_movement(self, launch_service, proc_info, proc_output):
+        proc_action = Node(
+            package="ros2_control_demo_test_utils",
+            executable="test_forward_command",
+            output="screen",
+        )
+
+        with launch_testing.tools.launch_process(
+            launch_service, proc_action, proc_info, proc_output
+        ):
+            proc_info.assertWaitForShutdown(process=proc_action, timeout=60)
+            launch_testing.asserts.assertExitCodes(
+                proc_info, process=proc_action, allowable_exit_codes=[0]
+            )
+
+
+@launch_testing.post_shutdown_test()
+class TestShutdown(unittest.TestCase):
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(proc_info)

--- a/ros2_control_demo_test_utils/package.xml
+++ b/ros2_control_demo_test_utils/package.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros2_control_demo_test_utils</name>
+  <version>0.0.0</version>
+  <description>Shared utilities for testing movement in ros2_control demos.</description>
+  <maintainer email="denis.stogl@stoglrobotics.de">Dr.-Ing. Denis Štogl</maintainer>
+  <maintainer email="bence.magyar.robotics@gmail.com">Bence Magyar</maintainer>
+  <maintainer email="christoph.froehlich@ait.ac.at">Christoph Froehlich</maintainer>
+  <maintainer email="sai.kishor@pal-robotics.com">Sai Kishor Kothakota</maintainer>
+  <author email="itzkamalkant@gmail.com">kamal2730</author>
+  <license>Apache-2.0</license>
+
+  <depend>rclpy</depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/ros2_control_demo_test_utils/package.xml
+++ b/ros2_control_demo_test_utils/package.xml
@@ -15,6 +15,8 @@
   <depend>std_msgs</depend>
   <depend>sensor_msgs</depend>
 
+  <test_depend>python3-pytest</test_depend>
+
   <export>
     <build_type>ament_python</build_type>
   </export>

--- a/ros2_control_demo_test_utils/ros2_control_demo_test_utils/__init__.py
+++ b/ros2_control_demo_test_utils/ros2_control_demo_test_utils/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/ros2_control_demo_test_utils/ros2_control_demo_test_utils/test_forward_command.py
+++ b/ros2_control_demo_test_utils/ros2_control_demo_test_utils/test_forward_command.py
@@ -1,0 +1,110 @@
+# Copyright 2026 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import rclpy
+from rclpy.node import Node
+
+from sensor_msgs.msg import JointState
+from std_msgs.msg import Float64MultiArray
+
+MIN_MOVEMENT = 0.1
+TIMEOUT = 15.0
+WAIT_FOR_JOINT_STATES_TIMEOUT = 10.0
+COMMAND_VALUE = 0.5
+
+
+class TestForwardCommand(Node):
+
+    def __init__(self):
+        super().__init__("test_forward_command")
+        self.declare_parameter("controller_name", "forward_position_controller")
+        self.declare_parameter("joints", ["joint1", "joint2"])
+
+        self.controller_name = self.get_parameter("controller_name").value
+        self.joints = self.get_parameter("joints").value
+        self.publish_topic = f"/{self.controller_name}/commands"
+
+        self.publisher_ = self.create_publisher(Float64MultiArray, self.publish_topic, 10)
+        self.joint_state_msg = None
+        self.subscription = self.create_subscription(
+            JointState, "/joint_states", self.joint_state_callback, 10
+        )
+
+    def joint_state_callback(self, msg):
+        self.joint_state_msg = msg
+
+    def run(self):
+        # 1. Wait for first joint state message
+        start_time = self.get_clock().now()
+        while self.joint_state_msg is None:
+            rclpy.spin_once(self, timeout_sec=0.1)
+            elapsed = (self.get_clock().now() - start_time).nanoseconds / 1e9
+            if elapsed > WAIT_FOR_JOINT_STATES_TIMEOUT:
+                self.get_logger().error("Timeout waiting for /joint_states")
+                return 1
+
+        # 2. Record and verify initial positions
+        msg = self.joint_state_msg
+        if not all(joint in msg.name for joint in self.joints):
+            self.get_logger().error(f"/joint_states does not contain joints {self.joints}")
+            return 1
+
+        indices = [msg.name.index(joint) for joint in self.joints]
+        init_positions = [msg.position[i] for i in indices]
+
+        self.get_logger().info(f"Initial positions: {dict(zip(self.joints, init_positions))}")
+
+        if any(abs(pos) > 0.01 for pos in init_positions):
+            self.get_logger().error("Joints not at initial position 0.0")
+            return 1
+
+        # 3. Publish position command
+        command = Float64MultiArray()
+        command.data = [COMMAND_VALUE] * len(self.joints)
+        self.publisher_.publish(command)
+        self.get_logger().info(f"Published command: {command.data}")
+
+        # 4. Wait for hardware simulation to respond
+        end_time = self.get_clock().now().nanoseconds + int(TIMEOUT * 1e9)
+        while self.get_clock().now().nanoseconds < end_time:
+            rclpy.spin_once(self, timeout_sec=0.1)
+
+        # 5. Check final positions
+        final_positions = [self.joint_state_msg.position[i] for i in indices]
+
+        self.get_logger().info(f"Final positions: {dict(zip(self.joints, final_positions))}")
+
+        if any(pos < MIN_MOVEMENT for pos in final_positions):
+            self.get_logger().error(
+                f"Joints did not move enough. "
+                f"Expected >{MIN_MOVEMENT}, got "
+                f"{dict(zip(self.joints, final_positions))}"
+            )
+            return 1
+
+        self.get_logger().info("Movement validated successfully")
+        return 0
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = TestForwardCommand()
+    result = node.run()
+    node.destroy_node()
+    rclpy.shutdown()
+    exit(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_control_demo_test_utils/ros2_control_demo_test_utils/test_forward_command.py
+++ b/ros2_control_demo_test_utils/ros2_control_demo_test_utils/test_forward_command.py
@@ -24,7 +24,7 @@ WAIT_FOR_JOINT_STATES_TIMEOUT = 10.0
 COMMAND_VALUE = 0.5
 
 
-class TestForwardCommand(Node):
+class ForwardCommand(Node):
 
     def __init__(self):
         super().__init__("test_forward_command")
@@ -99,7 +99,7 @@ class TestForwardCommand(Node):
 
 def main(args=None):
     rclpy.init(args=args)
-    node = TestForwardCommand()
+    node = ForwardCommand()
     result = node.run()
     node.destroy_node()
     rclpy.shutdown()

--- a/ros2_control_demo_test_utils/ros2_control_demo_test_utils/test_forward_command.py
+++ b/ros2_control_demo_test_utils/ros2_control_demo_test_utils/test_forward_command.py
@@ -18,10 +18,8 @@ from rclpy.node import Node
 from sensor_msgs.msg import JointState
 from std_msgs.msg import Float64MultiArray
 
-MIN_MOVEMENT = 0.1
 TIMEOUT = 15.0
 WAIT_FOR_JOINT_STATES_TIMEOUT = 10.0
-COMMAND_VALUE = 0.5
 
 
 class ForwardCommand(Node):
@@ -30,9 +28,17 @@ class ForwardCommand(Node):
         super().__init__("test_forward_command")
         self.declare_parameter("controller_name", "forward_position_controller")
         self.declare_parameter("joints", ["joint1", "joint2"])
+        self.declare_parameter("initial_position", 0.0)
+        self.declare_parameter("command_value", 0.5)
+        self.declare_parameter("position_tolerance", 0.01)
+        self.declare_parameter("min_movement", 0.1)
 
         self.controller_name = self.get_parameter("controller_name").value
         self.joints = self.get_parameter("joints").value
+        self.initial_position = self.get_parameter("initial_position").value
+        self.command_value = self.get_parameter("command_value").value
+        self.position_tolerance = self.get_parameter("position_tolerance").value
+        self.min_movement = self.get_parameter("min_movement").value
         self.publish_topic = f"/{self.controller_name}/commands"
 
         self.publisher_ = self.create_publisher(Float64MultiArray, self.publish_topic, 10)
@@ -65,13 +71,15 @@ class ForwardCommand(Node):
 
         self.get_logger().info(f"Initial positions: {dict(zip(self.joints, init_positions))}")
 
-        if any(abs(pos) > 0.01 for pos in init_positions):
-            self.get_logger().error("Joints not at initial position 0.0")
+        if any(
+            abs(pos - self.initial_position) > self.position_tolerance for pos in init_positions
+        ):
+            self.get_logger().error(f"Joints not at initial position {self.initial_position}")
             return 1
 
         # 3. Publish position command
         command = Float64MultiArray()
-        command.data = [COMMAND_VALUE] * len(self.joints)
+        command.data = [self.command_value] * len(self.joints)
         self.publisher_.publish(command)
         self.get_logger().info(f"Published command: {command.data}")
 
@@ -85,10 +93,10 @@ class ForwardCommand(Node):
 
         self.get_logger().info(f"Final positions: {dict(zip(self.joints, final_positions))}")
 
-        if any(pos < MIN_MOVEMENT for pos in final_positions):
+        if any(pos < self.min_movement for pos in final_positions):
             self.get_logger().error(
                 f"Joints did not move enough. "
-                f"Expected >{MIN_MOVEMENT}, got "
+                f"Expected >{self.min_movement}, got "
                 f"{dict(zip(self.joints, final_positions))}"
             )
             return 1

--- a/ros2_control_demo_test_utils/setup.cfg
+++ b/ros2_control_demo_test_utils/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/ros2_control_demo_test_utils
+[install]
+install_scripts=$base/lib/ros2_control_demo_test_utils

--- a/ros2_control_demo_test_utils/setup.py
+++ b/ros2_control_demo_test_utils/setup.py
@@ -1,0 +1,40 @@
+# Copyright 2026 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from setuptools import setup
+
+package_name = "ros2_control_demo_test_utils"
+
+setup(
+    name=package_name,
+    version="0.0.0",
+    packages=[package_name],
+    data_files=[
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        ("share/" + package_name, ["package.xml"]),
+    ],
+    install_requires=["setuptools"],
+    zip_safe=True,
+    author="kamal2730",
+    author_email="itzkamalkant@gmail.com",
+    maintainer="Dr.-Ing. Denis Štogl",
+    maintainer_email="denis.stogl@stoglrobotics.de",
+    description="Shared utilities for testing movement in ros2_control demos.",
+    license="Apache-2.0",
+    entry_points={
+        "console_scripts": [
+            "test_forward_command = ros2_control_demo_test_utils.test_forward_command:main",
+        ],
+    },
+)

--- a/ros2_control_demo_test_utils/setup.py
+++ b/ros2_control_demo_test_utils/setup.py
@@ -32,6 +32,7 @@ setup(
     maintainer_email="denis.stogl@stoglrobotics.de",
     description="Shared utilities for testing movement in ros2_control demos.",
     license="Apache-2.0",
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
             "test_forward_command = ros2_control_demo_test_utils.test_forward_command:main",

--- a/ros2_control_demo_test_utils/test/test_forward_command.py
+++ b/ros2_control_demo_test_utils/test/test_forward_command.py
@@ -35,5 +35,7 @@ class TestForwardCommandModule(unittest.TestCase):
             self.assertEqual(node.controller_name, "forward_position_controller")
             self.assertEqual(node.joints, ["joint1", "joint2"])
             self.assertEqual(node.publish_topic, "/forward_position_controller/commands")
+            self.assertEqual(node.command_value, 0.5)
+            self.assertEqual(node.position_tolerance, 0.01)
         finally:
             node.destroy_node()

--- a/ros2_control_demo_test_utils/test/test_forward_command.py
+++ b/ros2_control_demo_test_utils/test/test_forward_command.py
@@ -1,0 +1,39 @@
+# Copyright 2026 ros2_control Development Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+import rclpy
+
+from ros2_control_demo_test_utils.test_forward_command import ForwardCommand
+
+
+class TestForwardCommandModule(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def test_parameter_defaults(self):
+        node = ForwardCommand()
+        try:
+            self.assertEqual(node.controller_name, "forward_position_controller")
+            self.assertEqual(node.joints, ["joint1", "joint2"])
+            self.assertEqual(node.publish_topic, "/forward_position_controller/commands")
+        finally:
+            node.destroy_node()


### PR DESCRIPTION
# Summary
Adds movement integration testing to the ros2_control demos. A new shared `ros2_control_demo_test_utils` package provides `test_forward_command`, which publishes position commands and validates the resulting joint-state movement (exits 0 on success). A new launch test in example_1 (`test_rrbot_movement.py`) runs the executable via `launch_testing.tools.launch_process `and asserts its exit code, extending the existing launch tests to verify the robot actually moves.

First step toward adding integrated movement tests for all examples, addressing #1089 .