### PR TITLE
example_16: wire up 'prefix' launch arg to diff_drive_controller's tf…

### DIFF
--- a/example_16/bringup/config/diffbot_chained_controllers.yaml
+++ b/example_16/bringup/config/diffbot_chained_controllers.yaml
@@ -65,6 +65,7 @@ diffbot_base_controller:
     publish_rate: 50.0
     odom_frame_id: odom
     base_frame_id: base_link
+    tf_frame_prefix: "~"
     pose_covariance_diagonal : [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
     twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
 


### PR DESCRIPTION
Closes #1029.

`ros-controls/ros2_controllers#1997` changed `diff_drive_controller`'s parameter handling for `tf_frame_prefix`. Leaving it unset (the previous default) now triggers a runtime warning:

> Please use tilde ('~') character in 'tf_frame_prefix' as it replaced with node namespace

`example_16`'s config never set `tf_frame_prefix` at all, so every launch printed this warning. Setting it explicitly to `"~"` (the maintainer-recommended convention, which resolves to the controller's node namespace) silences it. Since this demo runs without a namespace, TF frame names are unaffected, this is a pure config-convention fix, no behavior change.

**Tested locally against ROS2 Jazzy:** the deprecation warning no longer appears on launch; all four controllers still load, configure, and activate normally.