### PR TITLE
docs: remove stale /dynamic_joint_states references

### DIFF
--- a/example_1/doc/userdoc.rst
+++ b/example_1/doc/userdoc.rst
@@ -212,7 +212,7 @@ Tutorial steps
     [ros2_control_node-1]   0.50 for joint 'joint2/position'
     [ros2_control_node-1]   0.50 for joint 'joint1/position'
 
-   If you echo the ``/joint_states`` or ``/dynamic_joint_states`` topics you should now get similar values, namely the simulated states of the robot
+   If you echo the ``/joint_states`` topic you should now get similar values, namely the simulated states of the robot
 
    .. tabs::
 
@@ -221,7 +221,6 @@ Tutorial steps
         .. code-block:: shell
 
           ros2 topic echo /joint_states
-          ros2 topic echo /dynamic_joint_states
 
       .. group-tab:: Docker
 
@@ -230,7 +229,6 @@ Tutorial steps
         .. code-block:: shell
 
           ros2 topic echo /joint_states
-          ros2 topic echo /dynamic_joint_states
 
 
 6. Let's switch to a different controller, the ``Joint Trajectory Controller``.

--- a/example_10/doc/userdoc.rst
+++ b/example_10/doc/userdoc.rst
@@ -59,51 +59,7 @@ The *RRBot* URDF files can be found in the ``description/urdf`` folder.
     gpio_controller             gpio_controllers/GpioCommandController               active
     forward_position_controller forward_command_controller/ForwardCommandController  active
 
-5. If you get output from above you can subscribe to the ``/dynamic_joint_states`` topic published by the *joint_state_broadcaster* using ROS 2 CLI interface:
-
-   .. code-block:: shell
-
-    ros2 topic echo /dynamic_joint_states --once
-
-
-   This includes not only the state interfaces of the joints but also the GPIO interfaces.
-
-   .. code-block:: shell
-
-      header:
-        stamp:
-          sec: 1730670203
-          nanosec: 875008879
-        frame_id: ''
-      joint_names:
-      - joint1
-      - joint2
-      - flange_vacuum
-      - flange_analog_IOs
-      interface_values:
-      - interface_names:
-        - position
-        values:
-        - 0.0
-      - interface_names:
-        - position
-        values:
-        - 0.0
-      - interface_names:
-        - vacuum
-        values:
-        - 0.0
-      - interface_names:
-        - analog_input2
-        - analog_input1
-        - analog_output1
-        values:
-        - 92747888.0
-        - 1764536320.0
-        - 0.0
-      ---
-
-   You can also subscribe to the ``/gpio_controller/gpio_states`` topic published by the *gpio_controller* using ROS 2 CLI interface:
+5. If you get output from above you can subscribe to the ``/gpio_controller/gpio_states`` topic published by the *gpio_controller* using ROS 2 CLI interface:
 
    .. code-block:: shell
 

--- a/example_12/doc/userdoc.rst
+++ b/example_12/doc/userdoc.rst
@@ -150,12 +150,11 @@ Tutorial steps
     [ros2_control_node-1]   0.50 for joint 'joint1'
     [ros2_control_node-1]   0.50 for joint 'joint2'
 
-   If you echo the ``/joint_states`` or ``/dynamic_joint_states`` topics you should now get similar values, namely the simulated states of the robot
+   If you echo the ``/joint_states`` topic you should now get similar values, namely the simulated states of the robot
 
    .. code-block:: shell
 
     ros2 topic echo /joint_states
-    ros2 topic echo /dynamic_joint_states
 
    This clearly shows that the controller chaining is functional, as the commands sent to the ``forward_position_controller`` are passed through properly and then it is reflected in the hardware interfaces of the *RRBot*.
 

--- a/example_9/doc/userdoc.rst
+++ b/example_9/doc/userdoc.rst
@@ -92,13 +92,12 @@ Tutorial steps
 
    You should now see the robot moving in gazebo.
 
-   If you echo the ``/joint_states`` or ``/dynamic_joint_states`` topics you should see the changing values,
+   If you echo the ``/joint_states`` topic you should see the changing values,
    namely the simulated states of the robot
 
    .. code-block:: shell
 
     ros2 topic echo /joint_states
-    ros2 topic echo /dynamic_joint_states
 
 
 Files used for this demos


### PR DESCRIPTION
ros-controls/ros2_controllers#2187 removed the dynamic_joint_states topic from joint_state_broadcaster. Several example docs still instructed users to echo it, which now just hangs waiting on a topic that is never published:

- example_1, example_9, example_12: dropped the dynamic_joint_states echo command from the /joint_states verification step; /joint_states alone already demonstrates the same thing.
- example_10: removed the dynamic_joint_states subsection of step 5 entirely. It was demonstrating GPIO interface introspection, but step 3 (ros2 control list_hardware_interfaces) and the remaining /gpio_controller/gpio_states subsection already cover that -- the removed section was fully redundant, not just outdated.

Docs-only change, verified by inspection (no runtime/build needed).

Fixes #1158
